### PR TITLE
Run the Playwright example tests on branches

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,22 @@
+name: Run example tests
+
+on: push
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+    - name: Download example test script
+      run: wget https://raw.githubusercontent.com/microsoft/create-playwright/main/assets/example.spec.ts
+      working-directory: tests
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test example


### PR DESCRIPTION
This is to give some confidence that dependency upgrades etc don't fundamentally break the tests.