### PR TITLE
Reduce global test timeout, and enable parallel tests on CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,15 +13,13 @@ import { devices } from '@playwright/test'
 const config: PlaywrightTestConfig = {
     testDir: './tests',
     /* Maximum time one test can run for. */
-    timeout: 480 * 1000,
+    timeout: 180 * 1000,
     /* Run tests in files in parallel */
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/tests/prison-custody-status-to-delius/release-recall-test.spec.ts
+++ b/tests/prison-custody-status-to-delius/release-recall-test.spec.ts
@@ -11,6 +11,8 @@ import { refreshUntil } from '../../steps/delius/utils/refresh'
 const nomisIds = []
 
 test('Release and recall test', async ({ page }) => {
+    test.slow() // increase the timeout - releases/recall publishing can take a few minutes
+
     // Given a person with a sentenced event in Delius
     await deliusLogin(page)
     const person = deliusPerson()


### PR DESCRIPTION
Tested here: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/3174549277