### PR TITLE
Return event outcome for case note contact check

### DIFF
--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -24,11 +24,9 @@ export async function verifyContact(page: Page, contact: Contact) {
         () => expect(matchingContactRecord).not.toHaveCount(0)
     )
 
-    const textArray = [contact.relatesTo, contact.type]
+    await expect(matchingContactRecord).toContainText(contact.relatesTo)
+    await expect(matchingContactRecord).toContainText(contact.type)
     if (contact.officer) {
-        textArray.push(`${contact.officer.lastName}, ${contact.officer.firstName}`)
+        await expect(matchingContactRecord).toContainText(`${contact.officer.lastName}, ${contact.officer.firstName}`)
     }
-    await expect(matchingContactRecord).toContainText(textArray[0])
-    await expect(matchingContactRecord).toContainText(textArray[1])
-    await expect(matchingContactRecord).toContainText(textArray[2])
 }

--- a/steps/delius/event/create-event.ts
+++ b/steps/delius/event/create-event.ts
@@ -26,6 +26,7 @@ export interface CreateEvent {
 
 export class CreatedEvent {
     court: string
+    outcome: string
     provider: string
 }
 
@@ -49,6 +50,7 @@ export async function createEvent(page: Page, { crn, allocation = {}, event }: C
     await selectOption(page, '#AppearanceType', event.appearanceType)
     await selectOption(page, '#Plea')
     await selectOption(page, '#addEventForm\\:Outcome', event.outcome)
+    createdEvent.outcome = event.outcome
     if (autoAddComponent.includes(event.outcome)) {
         await selectOption(page, '#OutcomeArea', allocation.providerName)
         await selectOption(page, '#addEventForm\\:OutcomeTeam', allocation.teamName)
@@ -82,13 +84,13 @@ export async function createEvent(page: Page, { crn, allocation = {}, event }: C
 export async function createCustodialEvent(
     page: Page,
     { crn, allocation = {}, event = data.events.custodial }: CreateEvent
-) {
+): Promise<CreatedEvent> {
     return createEvent(page, { crn, allocation, event })
 }
 
 export async function createCommunityEvent(
     page: Page,
     { crn, allocation = {}, event = data.events.community }: CreateEvent
-) {
+): Promise<CreatedEvent> {
     return createEvent(page, { crn, allocation, event })
 }


### PR DESCRIPTION
(this was accidentally changed in a previous PR)

~~Note: I haven't been able to test this locally yet due to VPN issues~~  Tested here: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/3175012897