### PR TITLE
Added End-to-End Tests for Unpaid Work Assessment Submission, Verification of the availability of UPW Assessment PDF in delius & refactoring of the End2End code to ensure test is running stable across applications

### DIFF
--- a/steps/delius/utils/date-time.ts
+++ b/steps/delius/utils/date-time.ts
@@ -12,5 +12,3 @@ export const LastMonth = subMonths(new Date(), 1)
 export const NextYear = addYears(new Date(), 1)
 export const Tomorrow = addDays(new Date(), 1)
 export const Yesterday = subDays(new Date(), 1)
-
-

--- a/steps/delius/utils/date-time.ts
+++ b/steps/delius/utils/date-time.ts
@@ -12,3 +12,5 @@ export const LastMonth = subMonths(new Date(), 1)
 export const NextYear = addYears(new Date(), 1)
 export const Tomorrow = addDays(new Date(), 1)
 export const Yesterday = subDays(new Date(), 1)
+
+

--- a/steps/unpaidwork/availability.ts
+++ b/steps/unpaidwork/availability.ts
@@ -8,11 +8,9 @@ export const completeAvailabilitySection = async (page: Page) => {
     await page.getByLabel('Available for work Friday morning').check()
     await page.getByLabel('Available for work Saturday afternoon').check()
     await page.getByLabel('Available for work Sunday morning').check()
-    await page
-        .getByRole('group', { name: 'Mark availability for community payback work section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#individual_availability_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Availability")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/availability.ts
+++ b/steps/unpaidwork/availability.ts
@@ -10,6 +10,6 @@ export const completeAvailabilitySection = async (page: Page) => {
     await page.getByLabel('Available for work Sunday morning').check()
     await page.locator('#individual_availability_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Availability")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Availability")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/availability.ts
+++ b/steps/unpaidwork/availability.ts
@@ -12,7 +12,4 @@ export const completeAvailabilitySection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Availability")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/caring-commitments.ts
+++ b/steps/unpaidwork/caring-commitments.ts
@@ -1,10 +1,10 @@
 import { expect, type Page } from '@playwright/test'
 
 export const completeCaringCommitmentsSection = async (page: Page) => {
-    await page.locator('#active_carer_commitments_details').click()
     await page.locator('#active_carer_commitments_details').fill('Entering Text related to the Caring Commitments')
-    await page.getByRole('group', { name: 'Mark caring commitments section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#caring_commitments_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Caring commitments")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/caring-commitments.ts
+++ b/steps/unpaidwork/caring-commitments.ts
@@ -4,6 +4,6 @@ export const completeCaringCommitmentsSection = async (page: Page) => {
     await page.locator('#active_carer_commitments_details').fill('Entering Text related to the Caring Commitments')
     await page.locator('#caring_commitments_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Caring commitments")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Caring commitments")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/caring-commitments.ts
+++ b/steps/unpaidwork/caring-commitments.ts
@@ -6,7 +6,4 @@ export const completeCaringCommitmentsSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Caring commitments")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/choose-equipment-sizes.ts
+++ b/steps/unpaidwork/choose-equipment-sizes.ts
@@ -8,7 +8,4 @@ export const completeEquipmentSizesSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Choose equipment sizes")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/choose-equipment-sizes.ts
+++ b/steps/unpaidwork/choose-equipment-sizes.ts
@@ -4,8 +4,9 @@ export const completeEquipmentSizesSection = async (page: Page) => {
     await page.getByLabel('Male', { exact: true }).check()
     await page.getByLabel('Large', { exact: true }).check()
     await page.getByRole('combobox', { name: 'Footwear' }).selectOption('9')
-    await page.getByRole('group', { name: 'Mark equipment sizes section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#equipment_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Choose equipment sizes")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/choose-equipment-sizes.ts
+++ b/steps/unpaidwork/choose-equipment-sizes.ts
@@ -6,6 +6,6 @@ export const completeEquipmentSizesSection = async (page: Page) => {
     await page.getByRole('combobox', { name: 'Footwear' }).selectOption('9')
     await page.locator('#equipment_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Choose equipment sizes")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Choose equipment sizes")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/complete-all-upw-sections.ts
+++ b/steps/unpaidwork/complete-all-upw-sections.ts
@@ -1,33 +1,38 @@
 import { type Page } from '@playwright/test'
 import {
     clickAvailabilityLink,
-    clickCaringCommitmentsLink, clickChooseEquipmentSizesLink,
+    clickCaringCommitmentsLink,
+    clickChooseEquipmentSizesLink,
     clickCulturalReligiousAdjustmentsLink,
-    clickDisabilitiesAndMentalHealthLink, clickEmplEducationSkillsLink,
-    clickGenderInformationLink, clickGPDetailsLink,
+    clickDisabilitiesAndMentalHealthLink,
+    clickEmplEducationSkillsLink,
+    clickGenderInformationLink,
+    clickGPDetailsLink,
     clickHealthIssuesLink,
-    clickIndividualDetailsLink, clickInstensiveWorkingLink,
+    clickIndividualDetailsLink,
+    clickInstensiveWorkingLink,
     clickManagingRiskLink,
     clickPlacementPreferencesLink,
-    clickRiskOfHarmCommunityLink, clickTrainingEmplOpprtunitiesLink,
-    clickTravelInformationLink
-} from "./task-list.js";
-import {completeIndividualDetailsSection} from "./individuals-details.js";
-import {completeGenderInformationSection} from "./gender-information.js";
-import {completeCulturalReligiousAdjustmentsSection} from "./cultural-and-religious-adjustments.js";
-import {completePlacementPreferencesSection} from "./placement-preferences.js";
-import {completeRiskHarmCommunitySection} from "./risk-of-harm-community.js";
-import {completeManagingRiskSection} from "./managing-risk.js";
-import {completeHealthIssuesSection} from "./health-issues.js";
-import {completeDisabilitiesAndMentalHealthSection} from "./disabilities-and-mental-health.js";
-import {completeCaringCommitmentsSection} from "./caring-commitments.js";
-import {completeTravelInformationSection} from "./travel-information.js";
-import {completeGPDetails} from "./gp-details.js";
-import {completeEmplEducationSkillsSection} from "./employment-education-skills.js";
-import {completeTrainingEmplOpportunitiesSection} from "./training-employment-opportunities.js";
-import {completeIntensiveWorkingSection} from "./intensive-working.js";
-import {completeEquipmentSizesSection} from "./choose-equipment-sizes.js";
-import {completeAvailabilitySection} from "./availability.js";
+    clickRiskOfHarmCommunityLink,
+    clickTrainingEmplOpprtunitiesLink,
+    clickTravelInformationLink,
+} from './task-list.js'
+import { completeIndividualDetailsSection } from './individuals-details.js'
+import { completeGenderInformationSection } from './gender-information.js'
+import { completeCulturalReligiousAdjustmentsSection } from './cultural-and-religious-adjustments.js'
+import { completePlacementPreferencesSection } from './placement-preferences.js'
+import { completeRiskHarmCommunitySection } from './risk-of-harm-community.js'
+import { completeManagingRiskSection } from './managing-risk.js'
+import { completeHealthIssuesSection } from './health-issues.js'
+import { completeDisabilitiesAndMentalHealthSection } from './disabilities-and-mental-health.js'
+import { completeCaringCommitmentsSection } from './caring-commitments.js'
+import { completeTravelInformationSection } from './travel-information.js'
+import { completeGPDetails } from './gp-details.js'
+import { completeEmplEducationSkillsSection } from './employment-education-skills.js'
+import { completeTrainingEmplOpportunitiesSection } from './training-employment-opportunities.js'
+import { completeIntensiveWorkingSection } from './intensive-working.js'
+import { completeEquipmentSizesSection } from './choose-equipment-sizes.js'
+import { completeAvailabilitySection } from './availability.js'
 
 export const completeAllUPWSections = async (page: Page) => {
     // And I click on "Individual's details" link

--- a/steps/unpaidwork/complete-all-upw-sections.ts
+++ b/steps/unpaidwork/complete-all-upw-sections.ts
@@ -1,0 +1,97 @@
+import { type Page } from '@playwright/test'
+import {
+    clickAvailabilityLink,
+    clickCaringCommitmentsLink, clickChooseEquipmentSizesLink,
+    clickCulturalReligiousAdjustmentsLink,
+    clickDisabilitiesAndMentalHealthLink, clickEmplEducationSkillsLink,
+    clickGenderInformationLink, clickGPDetailsLink,
+    clickHealthIssuesLink,
+    clickIndividualDetailsLink, clickInstensiveWorkingLink,
+    clickManagingRiskLink,
+    clickPlacementPreferencesLink,
+    clickRiskOfHarmCommunityLink, clickTrainingEmplOpprtunitiesLink,
+    clickTravelInformationLink
+} from "./task-list.js";
+import {completeIndividualDetailsSection} from "./individuals-details.js";
+import {completeGenderInformationSection} from "./gender-information.js";
+import {completeCulturalReligiousAdjustmentsSection} from "./cultural-and-religious-adjustments.js";
+import {completePlacementPreferencesSection} from "./placement-preferences.js";
+import {completeRiskHarmCommunitySection} from "./risk-of-harm-community.js";
+import {completeManagingRiskSection} from "./managing-risk.js";
+import {completeHealthIssuesSection} from "./health-issues.js";
+import {completeDisabilitiesAndMentalHealthSection} from "./disabilities-and-mental-health.js";
+import {completeCaringCommitmentsSection} from "./caring-commitments.js";
+import {completeTravelInformationSection} from "./travel-information.js";
+import {completeGPDetails} from "./gp-details.js";
+import {completeEmplEducationSkillsSection} from "./employment-education-skills.js";
+import {completeTrainingEmplOpportunitiesSection} from "./training-employment-opportunities.js";
+import {completeIntensiveWorkingSection} from "./intensive-working.js";
+import {completeEquipmentSizesSection} from "./choose-equipment-sizes.js";
+import {completeAvailabilitySection} from "./availability.js";
+
+export const completeAllUPWSections = async (page: Page) => {
+    // And I click on "Individual's details" link
+    await clickIndividualDetailsLink(page)
+    // And I complete "Individual's details" Section
+    await completeIndividualDetailsSection(page)
+    // And I click on "Gender information" link
+    await clickGenderInformationLink(page)
+    // And I complete "Gender information" Section
+    await completeGenderInformationSection(page)
+    // And I click on "Cultural and Religious Adjustments" link
+    await clickCulturalReligiousAdjustmentsLink(page)
+    // And I complete "Cultural and Religious Adjustments" Section
+    await completeCulturalReligiousAdjustmentsSection(page)
+    // And I click on "Placement preferencesCOMPLETED" link
+    await clickPlacementPreferencesLink(page)
+    // And I complete "Placement preferencesCOMPLETED" Section
+    await completePlacementPreferencesSection(page)
+    // And I click on "Risk of harm in the community" link
+    await clickRiskOfHarmCommunityLink(page)
+    // And I complete "Risk of harm in the community" Section
+    await completeRiskHarmCommunitySection(page)
+    // And I click on "Managing risk" link
+    await clickManagingRiskLink(page)
+    // And I complete "Managing risk" Section
+    await completeManagingRiskSection(page)
+    // And I click on "Disabilities and Mental Health" link
+    await clickDisabilitiesAndMentalHealthLink(page)
+    // And I complete "Disabilities and Mental Health" Section
+    await completeDisabilitiesAndMentalHealthSection(page)
+    // And I click on "Health Issues" link
+    await clickHealthIssuesLink(page)
+    // And I complete "Health Issues" Section
+    await completeHealthIssuesSection(page)
+    // And I click on "GP details" link
+    await clickGPDetailsLink(page)
+    // And I complete "GP details" Section
+    await completeGPDetails(page)
+    // And I click on "Travel" link
+    await clickTravelInformationLink(page)
+    // And I complete "Travel information" Section
+    await completeTravelInformationSection(page)
+    // And I click on "Caring commitments" link
+    await clickCaringCommitmentsLink(page)
+    // And I complete "Caring commitments" Section
+    await completeCaringCommitmentsSection(page)
+    // And I click on "Employment, education and skills" link
+    await clickEmplEducationSkillsLink(page)
+    // And I complete "Employment, education and skills" Section
+    await completeEmplEducationSkillsSection(page)
+    // And I click on "Training & employment opportunities" link
+    await clickTrainingEmplOpprtunitiesLink(page)
+    // And I complete "Training & employment opportunities" Section
+    await completeTrainingEmplOpportunitiesSection(page)
+    // And I click on "Intensive working" link
+    await clickInstensiveWorkingLink(page)
+    // And I complete "Intensive working" Section
+    await completeIntensiveWorkingSection(page)
+    // And I click on "Availability" link
+    await clickAvailabilityLink(page)
+    // And I complete "Availability" Section
+    await completeAvailabilitySection(page)
+    // And I click on "Choose equipment sizes" link
+    await clickChooseEquipmentSizesLink(page)
+    // And I complete "Choose equipment sizes" Section
+    await completeEquipmentSizesSection(page)
+}

--- a/steps/unpaidwork/cultural-and-religious-adjustments.ts
+++ b/steps/unpaidwork/cultural-and-religious-adjustments.ts
@@ -7,7 +7,4 @@ export const completeCulturalReligiousAdjustmentsSection = async (page: Page) =>
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Cultural and religious adjustments")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/cultural-and-religious-adjustments.ts
+++ b/steps/unpaidwork/cultural-and-religious-adjustments.ts
@@ -2,14 +2,10 @@ import { expect, type Page } from '@playwright/test'
 
 export const completeCulturalReligiousAdjustmentsSection = async (page: Page) => {
     await page.locator('#cultural_religious_adjustment').click()
-    await page
-        .locator('#cultural_religious_adjustment_details')
-        .fill('Entering Text related to Cultural and religious adjustments')
-    await page
-        .getByRole('group', { name: 'Mark cultural or religious adjustments section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#cultural_religious_adjustment_details').fill('Entering Text related to Cultural and religious adjustments')
+    await page.locator('#cultural_religious_adjustment_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Cultural and religious adjustments")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/cultural-and-religious-adjustments.ts
+++ b/steps/unpaidwork/cultural-and-religious-adjustments.ts
@@ -2,9 +2,13 @@ import { expect, type Page } from '@playwright/test'
 
 export const completeCulturalReligiousAdjustmentsSection = async (page: Page) => {
     await page.locator('#cultural_religious_adjustment').click()
-    await page.locator('#cultural_religious_adjustment_details').fill('Entering Text related to Cultural and religious adjustments')
+    await page
+        .locator('#cultural_religious_adjustment_details')
+        .fill('Entering Text related to Cultural and religious adjustments')
     await page.locator('#cultural_religious_adjustment_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Cultural and religious adjustments")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Cultural and religious adjustments")').first()).toContainText(
+        'COMPLETED'.toLowerCase()
+    )
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/disabilities-and-mental-health.ts
+++ b/steps/unpaidwork/disabilities-and-mental-health.ts
@@ -5,11 +5,9 @@ export const completeDisabilitiesAndMentalHealthSection = async (page: Page) => 
     await page.locator('#additional_disabilities_details').fill('Entering Text related to sexual offending')
     await page.locator('#disabilities').click()
     await page.locator('#disabilities_details').fill('Entering Text related to sexual offending')
-    await page
-        .getByRole('group', { name: 'Mark disabilities and mental health section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#disabilities_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Disabilities and mental health")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/disabilities-and-mental-health.ts
+++ b/steps/unpaidwork/disabilities-and-mental-health.ts
@@ -9,7 +9,4 @@ export const completeDisabilitiesAndMentalHealthSection = async (page: Page) => 
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Disabilities and mental health")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/disabilities-and-mental-health.ts
+++ b/steps/unpaidwork/disabilities-and-mental-health.ts
@@ -7,6 +7,8 @@ export const completeDisabilitiesAndMentalHealthSection = async (page: Page) => 
     await page.locator('#disabilities_details').fill('Entering Text related to sexual offending')
     await page.locator('#disabilities_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Disabilities and mental health")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Disabilities and mental health")').first()).toContainText(
+        'COMPLETED'.toLowerCase()
+    )
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/employment-education-skills.ts
+++ b/steps/unpaidwork/employment-education-skills.ts
@@ -1,51 +1,17 @@
 import { expect, type Page } from '@playwright/test'
 
 export const completeEmplEducationSkillsSection = async (page: Page) => {
-    await page
-        .getByRole('group', { name: 'Is the individual in employment or education?' })
-        .getByLabel('Full-time education or employment')
-        .check()
-    await page
-        .getByLabel('Employment or education details (working days, hours etc)')
-        .first()
-        .fill('Entering Text related to Full-time education')
-    await page
-        .getByRole('group', { name: 'Does the individual have any difficulties with reading, writing or numbers?' })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByRole('group', { name: 'Does the individual have any difficulties with reading, writing or numbers?' })
-        .getByLabel('Give details')
-        .fill('Entering Text related to writing difficulties')
-    await page
-        .getByRole('group', {
-            name: 'Does the individual have any work skills or experience that could be used while carrying out Community Payback?',
-        })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByRole('group', {
-            name: 'Does the individual have any work skills or experience that could be used while carrying out Community Payback?',
-        })
-        .getByLabel('Give details')
-        .fill('Entering Text related to work skills')
-    await page
-        .getByRole('group', {
-            name: 'Does the individual have future work plans that could be supported through a Community Payback placement?',
-        })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByRole('group', {
-            name: 'Does the individual have future work plans that could be supported through a Community Payback placement?',
-        })
-        .getByLabel('Give details')
-        .fill('Entering Text related to future work plans')
-    await page
-        .getByRole('group', { name: 'Mark employment, education and skills section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#employment_education').click()
+    await page.locator('#employment_education_details_fulltime').fill('Entering Text related to Full-time education')
+    await page.locator('#reading_writing_difficulties').click()
+    await page.locator('#reading_writing_difficulties_details').fill('Entering Text related to Full-time education')
+    await page.locator('#work_skills').click()
+    await page.locator('#work_skills_details').fill('Entering Text related to work skills')
+    await page.locator('#future_work_plans').click()
+    await page.locator('#future_work_plans_details').fill('Entering Text related to future work plans')
+    await page.locator('#employment_education_skills_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Employment, education and skills")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/employment-education-skills.ts
+++ b/steps/unpaidwork/employment-education-skills.ts
@@ -11,6 +11,8 @@ export const completeEmplEducationSkillsSection = async (page: Page) => {
     await page.locator('#future_work_plans_details').fill('Entering Text related to future work plans')
     await page.locator('#employment_education_skills_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Employment, education and skills")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Employment, education and skills")').first()).toContainText(
+        'COMPLETED'.toLowerCase()
+    )
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/employment-education-skills.ts
+++ b/steps/unpaidwork/employment-education-skills.ts
@@ -13,7 +13,4 @@ export const completeEmplEducationSkillsSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Employment, education and skills")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/gender-information.ts
+++ b/steps/unpaidwork/gender-information.ts
@@ -10,7 +10,4 @@ export const completeGenderInformationSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Gender information")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/gender-information.ts
+++ b/steps/unpaidwork/gender-information.ts
@@ -8,6 +8,6 @@ export const completeGenderInformationSection = async (page: Page) => {
     await page.locator('#transgender').check()
     await page.locator('#placement_preference_by_gender_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Gender information")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Gender information")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/gender-information.ts
+++ b/steps/unpaidwork/gender-information.ts
@@ -1,31 +1,14 @@
 import { expect, type Page } from '@playwright/test'
 
 export const completeGenderInformationSection = async (page: Page) => {
-    await page.locator('#gender_identity').check()
-    await page.getByLabel('Female').check()
-    await page
-        .getByRole('group', {
-            name: 'Has the individual gone through any part of a process to change the sex they were assigned at birth to the gender they now identify with, or do they intend to?',
-        })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByLabel(
-            'Give details and discuss placement options with the individual, based on their gender identity. Record their preference and the details of the conversation.'
-        )
-        .fill('Entering Text related to sex change')
-    await page
-        .getByRole('group', {
-            name: 'Is the individual intersex or do they have a Difference in Sexual Development (DSD)?',
-        })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByRole('group', { name: 'Do they consider themselves to be transgender or have a transgender history?' })
-        .getByLabel('Yes')
-        .check()
-    await page.getByRole('group', { name: 'Mark gender information section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#gender_identity-2').check()
+    await page.locator('#sex_change').check()
+    await page.locator('#sex_change_details').fill('Entering Text related to sex change')
+    await page.locator('#intersex_or_dsd').check()
+    await page.locator('#transgender').check()
+    await page.locator('#placement_preference_by_gender_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Gender information")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/gp-details.ts
+++ b/steps/unpaidwork/gp-details.ts
@@ -15,8 +15,9 @@ export const completeGPDetails = async (page: Page) => {
     await page.getByLabel('Phone number').fill(faker.phone.number())
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('.govuk-heading-xl')).toContainText('GP Details')
-    await page.getByRole('group', { name: 'Mark GP details section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#gp_details_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("GP Details")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/gp-details.ts
+++ b/steps/unpaidwork/gp-details.ts
@@ -17,6 +17,6 @@ export const completeGPDetails = async (page: Page) => {
     await expect(page.locator('.govuk-heading-xl')).toContainText('GP Details')
     await page.locator('#gp_details_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("GP Details")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("GP Details")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/gp-details.ts
+++ b/steps/unpaidwork/gp-details.ts
@@ -19,7 +19,4 @@ export const completeGPDetails = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("GP Details")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/health-issues.ts
+++ b/steps/unpaidwork/health-issues.ts
@@ -15,7 +15,4 @@ export const completeHealthIssuesSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Health issues")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/health-issues.ts
+++ b/steps/unpaidwork/health-issues.ts
@@ -13,6 +13,6 @@ export const completeHealthIssuesSection = async (page: Page) => {
     await page.locator('#other_health_issues_details').fill('Entering Text related to Other Health issues')
     await page.locator('#health_issues_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Health issues")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Health issues")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/health-issues.ts
+++ b/steps/unpaidwork/health-issues.ts
@@ -11,8 +11,9 @@ export const completeHealthIssuesSection = async (page: Page) => {
     await page.locator('#pregnancy_pregnant_details').fill('Entering Text related to Pregnancy')
     await page.locator('#other_health_issues').click()
     await page.locator('#other_health_issues_details').fill('Entering Text related to Other Health issues')
-    await page.getByRole('group', { name: 'Mark health issues section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#health_issues_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Health issues")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/individuals-details.ts
+++ b/steps/unpaidwork/individuals-details.ts
@@ -33,7 +33,4 @@ export const completeIndividualDetailsSection = async (page: Page) => {
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
     )
-
-
-
 }

--- a/steps/unpaidwork/individuals-details.ts
+++ b/steps/unpaidwork/individuals-details.ts
@@ -28,6 +28,6 @@ export const completeIndividualDetailsSection = async (page: Page) => {
     await expect(page.locator('#main-content h1')).toHaveText("Individual's details")
     await page.locator('#individual_details_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Individual\'s details")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Individual\'s details")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/individuals-details.ts
+++ b/steps/unpaidwork/individuals-details.ts
@@ -30,7 +30,4 @@ export const completeIndividualDetailsSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Individual\'s details")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/individuals-details.ts
+++ b/steps/unpaidwork/individuals-details.ts
@@ -19,20 +19,21 @@ export const completeIndividualDetailsSection = async (page: Page) => {
     await expect(page.locator('#main-content h1')).toHaveText("Individual's details")
     await page.getByRole('button', { name: 'Add contact' }).click()
     await expect(page.locator('#main-content h1')).toHaveText('Emergency contact')
-    await page.locator('#emergency_contact_first_name').click()
-    await page.locator('#emergency_contact_first_name').press('CapsLock')
     await page.locator('#emergency_contact_first_name').fill(faker.name.firstName())
     await page.getByLabel('Surname').fill(faker.name.lastName())
-    await page.getByLabel('Relationship to the individual').press('CapsLock')
     await page.getByLabel('Relationship to the individual').fill('Friend')
     await page.getByLabel('Mobile').fill(faker.phone.number())
     await page.getByLabel('Phone number').fill(faker.phone.number())
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('#main-content h1')).toHaveText("Individual's details")
-    await page.getByLabel('Yes').check()
+    await page.locator('#individual_details_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Individual\'s details")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
     )
+
+
+
 }

--- a/steps/unpaidwork/intensive-working.ts
+++ b/steps/unpaidwork/intensive-working.ts
@@ -10,7 +10,4 @@ export const completeIntensiveWorkingSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Intensive working")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/intensive-working.ts
+++ b/steps/unpaidwork/intensive-working.ts
@@ -1,25 +1,14 @@
 import { expect, type Page } from '@playwright/test'
 
 export const completeIntensiveWorkingSection = async (page: Page) => {
-    await page
-        .getByRole('group', { name: 'Is the individual eligible for intensive working?' })
-        .getByLabel('Yes')
-        .first()
-        .check()
-    await page
-        .getByRole('group', { name: 'Is the individual eligible for intensive working?' })
-        .getByLabel('Recommended hours per week in addition to statutory minimum, at the start of the order')
-        .fill('7')
-    await page
-        .getByRole('group', { name: 'Is the individual eligible for intensive working?' })
-        .getByLabel('Recommended hours per week in addition to statutory minimum, at the midpoint of the order')
-        .fill('21')
-    await page
-        .getByRole('group', { name: 'Is the individual eligible for intensive working?' })
-        .getByLabel('At what point should the individual be expected to reach a 28-hour working week?')
-        .fill('Entering Text related to 28-hour working week')
-    await page.getByRole('group', { name: 'Mark intensive working section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#eligibility_intensive_working').click()
+    await page.locator('#recommended_hours_start_order').fill('7')
+    await page.locator('#recommended_hours_midpoint_order').fill('21')
+    await page.locator('#twenty_eight_hours_working_week_details').fill('Entering Text related to 28-hour working week')
+    await page.locator('#eligibility_intensive_working_complete').click()
+    await page.locator('#eligibility_intensive_working_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Intensive working")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/intensive-working.ts
+++ b/steps/unpaidwork/intensive-working.ts
@@ -8,6 +8,6 @@ export const completeIntensiveWorkingSection = async (page: Page) => {
     await page.locator('#eligibility_intensive_working_complete').click()
     await page.locator('#eligibility_intensive_working_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Intensive working")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Intensive working")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/managing-risk.ts
+++ b/steps/unpaidwork/managing-risk.ts
@@ -26,7 +26,4 @@ export const completeManagingRiskSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Managing risk")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/managing-risk.ts
+++ b/steps/unpaidwork/managing-risk.ts
@@ -22,8 +22,9 @@ export const completeManagingRiskSection = async (page: Page) => {
         .fill('Entering Text related to supervised group')
     await page.locator('#alcohol_drug_issues').click()
     await page.locator('#alcohol_drug_issues_details').fill('Entering Text related to alcohol & drug issues')
-    await page.getByRole('group', { name: 'Mark managing risk section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#managing_risk_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Managing risk")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/managing-risk.ts
+++ b/steps/unpaidwork/managing-risk.ts
@@ -24,6 +24,6 @@ export const completeManagingRiskSection = async (page: Page) => {
     await page.locator('#alcohol_drug_issues_details').fill('Entering Text related to alcohol & drug issues')
     await page.locator('#managing_risk_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Managing risk")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Managing risk")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/placement-preferences.ts
+++ b/steps/unpaidwork/placement-preferences.ts
@@ -5,9 +5,11 @@ export const completePlacementPreferencesSection = async (page: Page) => {
         .getByRole('group', { name: 'Does the individual have any placement preferences?' })
         .getByLabel('Yes')
         .check()
-    await page.getByLabel('Individual').first().check()
-    await page.getByRole('group', { name: 'Mark placement preferences as complete?' }).getByLabel('Yes').check()
+    await page.locator('#placement_preference').check()
+    await page.locator('#placement_preferences').check()
+    await page.locator('#placement_preference_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Placement preferences")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/placement-preferences.ts
+++ b/steps/unpaidwork/placement-preferences.ts
@@ -9,6 +9,6 @@ export const completePlacementPreferencesSection = async (page: Page) => {
     await page.locator('#placement_preferences').check()
     await page.locator('#placement_preference_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Placement preferences")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Placement preferences")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/placement-preferences.ts
+++ b/steps/unpaidwork/placement-preferences.ts
@@ -11,7 +11,4 @@ export const completePlacementPreferencesSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Placement preferences")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/risk-of-harm-community.ts
+++ b/steps/unpaidwork/risk-of-harm-community.ts
@@ -27,7 +27,4 @@ export const completeRiskHarmCommunitySection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Risk of harm in the community")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/risk-of-harm-community.ts
+++ b/steps/unpaidwork/risk-of-harm-community.ts
@@ -23,11 +23,9 @@ export const completeRiskHarmCommunitySection = async (page: Page) => {
     await page.locator('#high_profile_person_details').fill(' Entering Text related to high-profile person')
     await page.locator('#additional_rosh_info').click()
     await page.locator('#additional_rosh_info_details').fill('Entering Text related to Additional information ')
-    await page
-        .getByRole('group', { name: 'Mark risk of harm in the community section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#rosh_community_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Risk of harm in the community")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/risk-of-harm-community.ts
+++ b/steps/unpaidwork/risk-of-harm-community.ts
@@ -25,6 +25,8 @@ export const completeRiskHarmCommunitySection = async (page: Page) => {
     await page.locator('#additional_rosh_info_details').fill('Entering Text related to Additional information ')
     await page.locator('#rosh_community_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Risk of harm in the community")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Risk of harm in the community")').first()).toContainText(
+        'COMPLETED'.toLowerCase()
+    )
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/task-list.ts
+++ b/steps/unpaidwork/task-list.ts
@@ -87,6 +87,7 @@ export const clickChooseEquipmentSizesLink = async (page: Page) => {
 }
 
 export const submitUPWAssessment = async (page: Page) => {
+    await expect(page.getByRole('link', { name: 'Completed assessment' })).toBeEnabled()
     await page.locator('.govuk-button', { hasText: 'Submit' }).click()
     await expect(page.locator('#main-content h1')).toContainText('You have completed the Community Payback assessment')
     await page.close()

--- a/steps/unpaidwork/task-list.ts
+++ b/steps/unpaidwork/task-list.ts
@@ -85,3 +85,11 @@ export const clickChooseEquipmentSizesLink = async (page: Page) => {
     await page.getByRole('link', { name: 'Choose equipment sizes' }).click()
     await expect(page.locator('#main-content h1')).toContainText('Choose equipment sizes')
 }
+
+export const submitAssessment = async (page: Page) => {
+    await page.locator('.govuk-button', { hasText: 'Submit' }).click()
+    await expect(page.locator('#main-content h1')).toContainText('You have completed the Community Payback assessment')
+}
+
+
+

--- a/steps/unpaidwork/task-list.ts
+++ b/steps/unpaidwork/task-list.ts
@@ -86,10 +86,8 @@ export const clickChooseEquipmentSizesLink = async (page: Page) => {
     await expect(page.locator('#main-content h1')).toContainText('Choose equipment sizes')
 }
 
-export const submitAssessment = async (page: Page) => {
+export const submitUPWAssessment = async (page: Page) => {
     await page.locator('.govuk-button', { hasText: 'Submit' }).click()
     await expect(page.locator('#main-content h1')).toContainText('You have completed the Community Payback assessment')
+    await page.close()
 }
-
-
-

--- a/steps/unpaidwork/training-employment-opportunities.ts
+++ b/steps/unpaidwork/training-employment-opportunities.ts
@@ -2,10 +2,14 @@ import { expect, type Page } from '@playwright/test'
 
 export const completeTrainingEmplOpportunitiesSection = async (page: Page) => {
     await page.locator('#education_training_need').click()
-    await page.locator('#education_training_need_details').fill('Entering Text related to education, training or employment-related need')
+    await page
+        .locator('#education_training_need_details')
+        .fill('Entering Text related to education, training or employment-related need')
     await page.locator('#individual_commitment').click()
     await page.locator('#employment_training_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Training & employment opportunities")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Training & employment opportunities")').first()).toContainText(
+        'COMPLETED'.toLowerCase()
+    )
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/training-employment-opportunities.ts
+++ b/steps/unpaidwork/training-employment-opportunities.ts
@@ -1,29 +1,12 @@
 import { expect, type Page } from '@playwright/test'
 
 export const completeTrainingEmplOpportunitiesSection = async (page: Page) => {
-    await page
-        .getByRole('group', { name: 'Does the individual have an education, training or employment-related need?' })
-        .first()
-        .getByLabel('Yes')
-        .first()
-        .check()
-    await page
-        .getByRole('group', { name: 'Does the individual have an education, training or employment-related need?' })
-        .first()
-        .getByLabel('Give details')
-        .first()
-        .fill('Entering Text related to education, training or employment-related need')
-    await page
-        .getByRole('group', {
-            name: 'Does the individual agree to use the maximum entitlement of their hours on this activity?',
-        })
-        .getByLabel('Yes')
-        .check()
-    await page
-        .getByRole('group', { name: 'Mark training and employment section as complete?' })
-        .getByLabel('Yes')
-        .check()
+    await page.locator('#education_training_need').click()
+    await page.locator('#education_training_need_details').fill('Entering Text related to education, training or employment-related need')
+    await page.locator('#individual_commitment').click()
+    await page.locator('#employment_training_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Training & employment opportunities")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/training-employment-opportunities.ts
+++ b/steps/unpaidwork/training-employment-opportunities.ts
@@ -8,7 +8,4 @@ export const completeTrainingEmplOpportunitiesSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Training & employment opportunities")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/steps/unpaidwork/travel-information.ts
+++ b/steps/unpaidwork/travel-information.ts
@@ -8,6 +8,6 @@ export const completeTravelInformationSection = async (page: Page) => {
     await page.locator('#public_transport').click()
     await page.locator('#travel_information_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.locator('li:has-text("Travel")').first()).toContainText(('COMPLETED').toLowerCase())
+    await expect(page.locator('li:has-text("Travel")').first()).toContainText('COMPLETED'.toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
 }

--- a/steps/unpaidwork/travel-information.ts
+++ b/steps/unpaidwork/travel-information.ts
@@ -6,8 +6,9 @@ export const completeTravelInformationSection = async (page: Page) => {
     await page.locator('#driving_licence').click()
     await page.locator('#vehicle').click()
     await page.locator('#public_transport').click()
-    await page.getByRole('group', { name: 'Mark travel information section as complete?' }).getByLabel('Yes').check()
+    await page.locator('#travel_information_complete').click()
     await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.locator('li:has-text("Travel")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
     await expect(page.locator('.govuk-caption-l')).toHaveText(
         'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'

--- a/steps/unpaidwork/travel-information.ts
+++ b/steps/unpaidwork/travel-information.ts
@@ -10,7 +10,4 @@ export const completeTravelInformationSection = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('li:has-text("Travel")').first()).toContainText(('COMPLETED').toLowerCase())
     await expect(page.locator('#main-content h1')).toHaveText('Community payback assessment')
-    await expect(page.locator('.govuk-caption-l')).toHaveText(
-        'Most of the questions in this assessment must be answered, but some are optional and are marked as such.'
-    )
 }

--- a/tests/DRAFT-unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/DRAFT-unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import {expect, test} from '@playwright/test'
 import * as dotenv from 'dotenv'
 dotenv.config() // read environment variables into process.env
 import { login as deliusLogin } from '../../steps/delius/login.js'
@@ -10,44 +10,12 @@ import { data } from '../../test-data/test-data.js'
 import { createRequirementForEvent } from '../../steps/delius/requirement/create-requirement.js'
 import { startUPWAssessmentFromDelius } from '../../steps/delius/upw/start-upw-assessment.js'
 import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
-import { completeIndividualDetailsSection } from '../../steps/unpaidwork/individuals-details.js'
-import {
-    clickAvailabilityLink,
-    clickCaringCommitmentsLink,
-    clickChooseEquipmentSizesLink,
-    clickCulturalReligiousAdjustmentsLink,
-    clickDisabilitiesAndMentalHealthLink,
-    clickEmplEducationSkillsLink,
-    clickGenderInformationLink,
-    clickGPDetailsLink,
-    clickHealthIssuesLink,
-    clickIndividualDetailsLink,
-    clickInstensiveWorkingLink,
-    clickManagingRiskLink,
-    clickPlacementPreferencesLink,
-    clickRiskOfHarmCommunityLink,
-    clickTrainingEmplOpprtunitiesLink,
-    clickTravelInformationLink,
-} from '../../steps/unpaidwork/task-list.js'
-import { completeGenderInformationSection } from '../../steps/unpaidwork/gender-information.js'
-import { completeCulturalReligiousAdjustmentsSection } from '../../steps/unpaidwork/cultural-and-religious-adjustments.js'
-import { completePlacementPreferencesSection } from '../../steps/unpaidwork/placement-preferences.js'
-import { completeRiskHarmCommunitySection } from '../../steps/unpaidwork/risk-of-harm-community.js'
-import { completeManagingRiskSection } from '../../steps/unpaidwork/managing-risk.js'
-import { completeHealthIssuesSection } from '../../steps/unpaidwork/health-issues.js'
-import { completeDisabilitiesAndMentalHealthSection } from '../../steps/unpaidwork/disabilities-and-mental-health.js'
-import { completeCaringCommitmentsSection } from '../../steps/unpaidwork/caring-commitments.js'
-import { completeTravelInformationSection } from '../../steps/unpaidwork/travel-information.js'
-import { completeGPDetails } from '../../steps/unpaidwork/gp-details.js'
-import { completeEmplEducationSkillsSection } from '../../steps/unpaidwork/employment-education-skills.js'
-import { completeTrainingEmplOpportunitiesSection } from '../../steps/unpaidwork/training-employment-opportunities.js'
-import { completeIntensiveWorkingSection } from '../../steps/unpaidwork/intensive-working.js'
-import { completeAvailabilitySection } from '../../steps/unpaidwork/availability.js'
-import { completeEquipmentSizesSection } from '../../steps/unpaidwork/choose-equipment-sizes.js'
+import {submitAssessment} from '../../steps/unpaidwork/task-list.js'
+import {findOffenderByCRN} from "../../steps/delius/offender/find-offender.js";
+import {completeAllUPWSections} from "../../steps/unpaidwork/complete-all-upw-sections.js";
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
-    test.skip()
     // Given I create new Offender in nDelius
     await deliusLogin(page)
     const person = deliusPerson()
@@ -62,74 +30,24 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
     const { nomisId } = await createAndBookPrisoner(page, crn, person)
     nomisIds.push(nomisId)
+
     // And I start UPW Assessment from Delius
     const popup = await startUPWAssessmentFromDelius(page)
     // When I login to UPW and navigate to UPW Task List
     await unpaidWorkLogin(popup)
-    // And I click on "Individual's details" link
-    await clickIndividualDetailsLink(popup)
-    // And I complete "Individual's details" Section
-    await completeIndividualDetailsSection(popup)
-    // And I click on "Gender information" link
-    await clickGenderInformationLink(popup)
-    // And I complete "Gender information" Section
-    await completeGenderInformationSection(popup)
-    // And I click on "Cultural and Religious Adjustments" link
-    await clickCulturalReligiousAdjustmentsLink(popup)
-    // And I complete "Cultural and Religious Adjustments" Section
-    await completeCulturalReligiousAdjustmentsSection(popup)
-    // And I click on "Placement preferencesCOMPLETED" link
-    await clickPlacementPreferencesLink(popup)
-    // And I complete "Placement preferencesCOMPLETED" Section
-    await completePlacementPreferencesSection(popup)
-    // And I click on "Risk of harm in the community" link
-    await clickRiskOfHarmCommunityLink(popup)
-    // And I complete "Risk of harm in the community" Section
-    await completeRiskHarmCommunitySection(popup)
-    // And I click on "Managing risk" link
-    await clickManagingRiskLink(popup)
-    // And I complete "Managing risk" Section
-    await completeManagingRiskSection(popup)
-    // And I click on "Health Issues" link
-    await clickHealthIssuesLink(popup)
-    // And I complete "Health Issues" Section
-    await completeHealthIssuesSection(popup)
-    // And I click on "Disabilities and Mental Health" link
-    await clickDisabilitiesAndMentalHealthLink(popup)
-    // And I complete "Disabilities and Mental Health" Section
-    await completeDisabilitiesAndMentalHealthSection(popup)
-    // And I click on "Caring commitments" link
-    await clickCaringCommitmentsLink(popup)
-    // And I complete "Caring commitments" Section
-    await completeCaringCommitmentsSection(popup)
-    // And I click on "Travel" link
-    await clickTravelInformationLink(popup)
-    // And I complete "Travel information" Section
-    await completeTravelInformationSection(popup)
-    // And I click on "GP details" link
-    await clickGPDetailsLink(popup)
-    // And I complete "GP details" Section
-    await completeGPDetails(popup)
-    // And I click on "Employment, education and skills" link
-    await clickEmplEducationSkillsLink(popup)
-    // And I complete "Employment, education and skills" Section
-    await completeEmplEducationSkillsSection(popup)
-    // And I click on "Training & employment opportunities" link
-    await clickTrainingEmplOpprtunitiesLink(popup)
-    // And I complete "Training & employment opportunities" Section
-    await completeTrainingEmplOpportunitiesSection(popup)
-    // And I click on "Intensive working" link
-    await clickInstensiveWorkingLink(popup)
-    // And I complete "Intensive working" Section
-    await completeIntensiveWorkingSection(popup)
-    // And I click on "Availability" link
-    await clickAvailabilityLink(popup)
-    // And I complete "Availability" Section
-    await completeAvailabilitySection(popup)
-    // And I click on "Choose equipment sizes" link
-    await clickChooseEquipmentSizesLink(popup)
-    // And I complete "Choose equipment sizes" Section
-    await completeEquipmentSizesSection(popup)
+    // And I complete all the UPW Sections
+    await completeAllUPWSections(popup)
+    // And I submit UPW Assessment
+    await submitAssessment(popup)
+    await popup.close()
+
+    // And login to nDelius
+    await deliusLogin(page)
+    // And I Search for offender with CRN
+    await findOffenderByCRN(page, crn)
+    // Then the document appears in the Delius document list
+    await page.locator('a', {hasText: 'Document List'}).click()
+    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText('CP/UPW Assessment')
 })
 
 test.afterAll(async () => {

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -1,4 +1,4 @@
-import {expect, test} from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import * as dotenv from 'dotenv'
 dotenv.config() // read environment variables into process.env
 import { login as deliusLogin } from '../../steps/delius/login.js'
@@ -10,9 +10,9 @@ import { data } from '../../test-data/test-data.js'
 import { createRequirementForEvent } from '../../steps/delius/requirement/create-requirement.js'
 import { startUPWAssessmentFromDelius } from '../../steps/delius/upw/start-upw-assessment.js'
 import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
-import {submitUPWAssessment} from '../../steps/unpaidwork/task-list.js'
-import {completeAllUPWSections} from "../../steps/unpaidwork/complete-all-upw-sections.js";
-import {format} from "date-fns";
+import { submitUPWAssessment } from '../../steps/unpaidwork/task-list.js'
+import { completeAllUPWSections } from '../../steps/unpaidwork/complete-all-upw-sections.js'
+import { format } from 'date-fns'
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
@@ -21,7 +21,10 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
     // And I create Supervision Community Event in Delius
-    await createCommunityEvent(page, {crn, allocation: { team: data.teams.allocationsTestTeam, staff: data.staff.allocationsTester2 },})
+    await createCommunityEvent(page, {
+        crn,
+        allocation: { team: data.teams.allocationsTestTeam, staff: data.staff.allocationsTester2 },
+    })
     // And I add a requirement for this event with the type called "unpaid work"
     await createRequirementForEvent(page, { crn, requirement: data.requirements.unpaidWork })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
@@ -38,9 +41,13 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     await submitUPWAssessment(popup)
 
     // Then the document appears in the Delius document list
-    await page.locator('a', {hasText: 'Document List'}).click()
-    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText('CP/UPW Assessment')
-    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(format(new Date(), "dd/MM/yyyy"))
+    await page.locator('a', { hasText: 'Document List' }).click()
+    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
+        'CP/UPW Assessment'
+    )
+    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
+        format(new Date(), 'dd/MM/yyyy')
+    )
     await expect(page.getByRole('link', { name: 'view document' })).toBeEnabled()
 })
 

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -10,7 +10,7 @@ import { data } from '../../test-data/test-data.js'
 import { createRequirementForEvent } from '../../steps/delius/requirement/create-requirement.js'
 import { startUPWAssessmentFromDelius } from '../../steps/delius/upw/start-upw-assessment.js'
 import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
-import {submitAssessment, submitUPWAssessment} from '../../steps/unpaidwork/task-list.js'
+import {submitUPWAssessment} from '../../steps/unpaidwork/task-list.js'
 import {findOffenderByCRN} from "../../steps/delius/offender/find-offender.js";
 import {completeAllUPWSections} from "../../steps/unpaidwork/complete-all-upw-sections.js";
 

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -11,8 +11,8 @@ import { createRequirementForEvent } from '../../steps/delius/requirement/create
 import { startUPWAssessmentFromDelius } from '../../steps/delius/upw/start-upw-assessment.js'
 import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
 import {submitUPWAssessment} from '../../steps/unpaidwork/task-list.js'
-import {findOffenderByCRN} from "../../steps/delius/offender/find-offender.js";
 import {completeAllUPWSections} from "../../steps/unpaidwork/complete-all-upw-sections.js";
+import {format} from "date-fns";
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
@@ -34,16 +34,14 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     await unpaidWorkLogin(popup)
     // And I complete all the UPW Sections
     await completeAllUPWSections(popup)
-    // And I submit UPW Assessment
+    // And I submit UPW Assessment and close the UPW Popup
     await submitUPWAssessment(popup)
 
-    // And login to nDelius
-    await deliusLogin(page)
-    // And I Search for offender with CRN
-    await findOffenderByCRN(page, crn)
-    await page.locator('a', {hasText: 'Document List'}).click()
     // Then the document appears in the Delius document list
+    await page.locator('a', {hasText: 'Document List'}).click()
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText('CP/UPW Assessment')
+    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(format(new Date(), "dd/MM/yyyy"))
+    await expect(page.getByRole('link', { name: 'view document' })).toBeEnabled()
 })
 
 test.afterAll(async () => {


### PR DESCRIPTION
Given I create new Offender in nDelius
And I create Supervision Community Event in Delius
And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
And I add a requirement for this event with the type called "unpaid work"
And I start UPW Assessment from Delius
When I login to UPW and navigate to UPW Task List
And I complete all the UPW Sections
And I submit UPW Assessment and close the UPW Popup
Then the UPW Pdf document appears in the Delius document list