### PR TITLE
Improved End-to-End Tests by amending RSR code, optimising "Allocations" tests with a long-term solution, skipping create booking, removing random selection of provider teams, and implementing other minor changes for enhanced stability

### DIFF
--- a/steps/delius/contact/create-contact.ts
+++ b/steps/delius/contact/create-contact.ts
@@ -28,7 +28,7 @@ export const createContact = async (page: Page, crn: string, options: Contact) =
     if (options.endTime) {
         await fillTime(page, '#addContactForm\\:EndTime', options.endTime)
     }
-        await selectOptionAndWait(page, '#addContactForm\\:TransferToOfficer', options.allocation?.staff?.name)
+    await selectOptionAndWait(page, '#addContactForm\\:TransferToOfficer', options.allocation?.staff?.name)
     await doUntil(
         () => page.locator('#addContactForm\\:saveButton').click(),
         () => expect(page).toHaveTitle(/Contact List/)

--- a/steps/delius/contact/create-contact.ts
+++ b/steps/delius/contact/create-contact.ts
@@ -3,7 +3,7 @@ import { findContactsByCRN } from './find-contacts.js'
 import { fillDate, fillTime, selectOptionAndWait } from '../utils/inputs.js'
 import { Contact, data, Team } from '../../../test-data/test-data.js'
 import { doUntil } from '../utils/refresh.js'
-import {Tomorrow} from "../utils/date-time.js";
+import { Tomorrow } from '../utils/date-time.js'
 
 export const createContact = async (page: Page, crn: string, options: Contact) => {
     await findContactsByCRN(page, crn)

--- a/steps/delius/contact/create-contact.ts
+++ b/steps/delius/contact/create-contact.ts
@@ -3,6 +3,7 @@ import { findContactsByCRN } from './find-contacts.js'
 import { fillDate, fillTime, selectOptionAndWait } from '../utils/inputs.js'
 import { Contact, data, Team } from '../../../test-data/test-data.js'
 import { doUntil } from '../utils/refresh.js'
+import {Tomorrow} from "../utils/date-time.js";
 
 export const createContact = async (page: Page, crn: string, options: Contact) => {
     await findContactsByCRN(page, crn)
@@ -27,7 +28,7 @@ export const createContact = async (page: Page, crn: string, options: Contact) =
     if (options.endTime) {
         await fillTime(page, '#addContactForm\\:EndTime', options.endTime)
     }
-    await selectOptionAndWait(page, '#addContactForm\\:TransferToOfficer', options.allocation?.staff?.name)
+        await selectOptionAndWait(page, '#addContactForm\\:TransferToOfficer', options.allocation?.staff?.name)
     await doUntil(
         () => page.locator('#addContactForm\\:saveButton').click(),
         () => expect(page).toHaveTitle(/Contact List/)
@@ -38,7 +39,8 @@ export const createInitialAppointment = async (page: Page, crn: string, eventNum
     createContact(page, crn, {
         relatesTo: `Event ${eventNumber} - ORA Community Order (6 Months)`,
         allocation: { team: team },
-        startTime: new Date(),
-        endTime: new Date(new Date().getTime() + 60000),
+        date: Tomorrow,
+        startTime: Tomorrow,
+        endTime: new Date(Tomorrow.getTime() + 60000),
         ...data.contacts.initialAppointment,
     })

--- a/steps/delius/utils/date-time.ts
+++ b/steps/delius/utils/date-time.ts
@@ -1,5 +1,4 @@
 import { addMonths, addYears, addDays, subMonths, subDays } from 'date-fns'
-
 export const options = { day: 'numeric', month: 'long', year: 'numeric' } as Intl.DateTimeFormatOptions
 export const recallDateFormatter = date => date.toLocaleDateString('en-GB', options)
 export const DeliusDateFormatter = (date: Date) => date.toLocaleDateString('en-GB')

--- a/steps/make-recall-decisions/start-recommendation.ts
+++ b/steps/make-recall-decisions/start-recommendation.ts
@@ -45,7 +45,7 @@ export const verifyRecallOffendersAddress = async (
 
 export const verifyLicenceCondition = async (page: Page, licenceCondition: string): Promise<void> => {
     await page.getByRole('link', { name: 'Licence conditions' }).click()
-    const recallLicenseDesc = await page.locator('[data-qa="condition-description"]').textContent()
+    const recallLicenseDesc = await page.locator('#accordion-with-summary-sections-content-2 p, [data-qa="condition-description"]').first().textContent()
     await expect(recallLicenseDesc).toMatch(licenceCondition.replace(/(.*)-/, '').trim())
 }
 

--- a/steps/make-recall-decisions/start-recommendation.ts
+++ b/steps/make-recall-decisions/start-recommendation.ts
@@ -45,7 +45,10 @@ export const verifyRecallOffendersAddress = async (
 
 export const verifyLicenceCondition = async (page: Page, licenceCondition: string): Promise<void> => {
     await page.getByRole('link', { name: 'Licence conditions' }).click()
-    const recallLicenseDesc = await page.locator('#accordion-with-summary-sections-content-2 p, [data-qa="condition-description"]').first().textContent()
+    const recallLicenseDesc = await page
+        .locator('#accordion-with-summary-sections-content-2 p, [data-qa="condition-description"]')
+        .first()
+        .textContent()
     await expect(recallLicenseDesc).toMatch(licenceCondition.replace(/(.*)-/, '').trim())
 }
 

--- a/steps/oasys/offender-rsr-score .ts
+++ b/steps/oasys/offender-rsr-score .ts
@@ -1,5 +1,5 @@
 import { type Page, expect } from '@playwright/test'
-import {doUntil} from "../delius/utils/refresh.js";
+import { doUntil } from '../delius/utils/refresh.js'
 
 export const inputRSRScoreAnswers = async (page: Page) => {
     await page.fill('#P5_CT_OFFENCE_CODE_TEXT', '029')
@@ -14,7 +14,7 @@ export const inputRSRScoreAnswers = async (page: Page) => {
     await page.fill('#P5_QU_1_38', '31122021')
     await page.locator('#P5_QU_1_39').selectOption({ label: 'No' })
     await doUntil(
-        () =>  page.click('#P5_BT_CALC_RSR_BOTTOM_WARN'),
+        () => page.click('#P5_BT_CALC_RSR_BOTTOM_WARN'),
         () => expect(page.locator('#P5_RSR_TEXT_1')).toHaveText(/RSR score \(STATIC\) is .*/)
     )
 }

--- a/steps/oasys/offender-rsr-score .ts
+++ b/steps/oasys/offender-rsr-score .ts
@@ -1,4 +1,5 @@
 import { type Page, expect } from '@playwright/test'
+import {doUntil} from "../delius/utils/refresh.js";
 
 export const inputRSRScoreAnswers = async (page: Page) => {
     await page.fill('#P5_CT_OFFENCE_CODE_TEXT', '029')
@@ -12,7 +13,10 @@ export const inputRSRScoreAnswers = async (page: Page) => {
     await page.locator('#P5_QU_1_30').selectOption({ label: 'No' })
     await page.fill('#P5_QU_1_38', '31122021')
     await page.locator('#P5_QU_1_39').selectOption({ label: 'No' })
-    await page.click('#P5_BT_CALC_RSR_BOTTOM_WARN')
+    await doUntil(
+        () =>  page.click('#P5_BT_CALC_RSR_BOTTOM_WARN'),
+        () => expect(page.locator('#P5_RSR_TEXT_1')).toHaveText(/RSR score \(STATIC\) is .*/)
+    )
 }
 
 export const verifyRSRScoreGeneration = async (page: Page): Promise<string> => {

--- a/steps/workforce/allocations.ts
+++ b/steps/workforce/allocations.ts
@@ -2,7 +2,7 @@ import { expect, type Page } from '@playwright/test'
 import { refreshUntil } from '../delius/utils/refresh.js'
 import { WorkforceDateFormat } from './utils.js'
 import { Allocation, Team } from '../../test-data/test-data.js'
-import { Tomorrow } from "../delius/utils/date-time.js";
+import { Tomorrow } from '../delius/utils/date-time.js'
 
 export const viewAllocation = async (page: Page, crn: string) => {
     const matchingRow = page.locator('tr', { hasText: crn })
@@ -38,7 +38,7 @@ export const allocateCase = async (page: Page, crn: string, allocation: Allocati
     await page.fill('#instructions', `Allocation for ${crn} completed by hmpps-end-to-end-tests`)
     await page.locator('button', { hasText: 'Allocate Case' }).click()
     await page.locator('div.govuk-panel--confirmation >> h1.govuk-panel__title', { hasText: 'Allocation complete' })
-    await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/));
+    await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/))
 }
 
 export const selectTeam = async (page: Page, team: Team) => {

--- a/steps/workforce/allocations.ts
+++ b/steps/workforce/allocations.ts
@@ -2,12 +2,12 @@ import { expect, type Page } from '@playwright/test'
 import { refreshUntil } from '../delius/utils/refresh.js'
 import { WorkforceDateFormat } from './utils.js'
 import { Allocation, Team } from '../../test-data/test-data.js'
-import {Tomorrow} from "../delius/utils/date-time.js";
+import { Tomorrow } from "../delius/utils/date-time.js";
 
 export const viewAllocation = async (page: Page, crn: string) => {
     const matchingRow = page.locator('tr', { hasText: crn })
     await refreshUntil(page, () => expect(matchingRow).not.toHaveCount(0))
-    // await expect(matchingRow).toContainText(WorkforceDateFormat(Tomorrow))
+    await expect(matchingRow).toContainText(WorkforceDateFormat(Tomorrow))
     await matchingRow.locator(`[href*=${crn}]`).click()
     await expect(page.locator('.govuk-caption-xl', { hasText: crn })).toHaveText(`CRN: ${crn}`)
 }
@@ -20,8 +20,7 @@ export const allocateCase = async (page: Page, crn: string, allocation: Allocati
     await viewAllocation(page, crn)
     // Navigate to allocation page
     await page.locator('a', { hasText: 'Continue' }).click()
-    await refreshUntil(page, () => expect(page).toHaveTitle(/.*Choose practitioner.*/))
-    // await expect(page).toHaveTitle(/.*Choose practitioner.*/)
+    await expect(page).toHaveTitle(/.*Choose practitioner.*/)
 
     // Allocate to team/staff
     await page
@@ -38,7 +37,7 @@ export const allocateCase = async (page: Page, crn: string, allocation: Allocati
     await expect(page).toHaveTitle(/.*Review allocation instructions.*/)
     await page.fill('#instructions', `Allocation for ${crn} completed by hmpps-end-to-end-tests`)
     await page.locator('button', { hasText: 'Allocate Case' }).click()
-    // await page.locator('div.govuk-panel--confirmation >> h1.govuk-panel__title', { hasText: 'Allocation complete' })
+    await page.locator('div.govuk-panel--confirmation >> h1.govuk-panel__title', { hasText: 'Allocation complete' })
     await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/));
 }
 

--- a/steps/workforce/login.ts
+++ b/steps/workforce/login.ts
@@ -1,5 +1,4 @@
 import { type Page, expect } from '@playwright/test'
-import { refreshUntil } from '../delius/utils/refresh.js'
 
 export const login = async (page: Page) => {
     await page.goto(process.env.WORKFORCE_URL)

--- a/steps/workforce/login.ts
+++ b/steps/workforce/login.ts
@@ -1,5 +1,5 @@
 import { type Page, expect } from '@playwright/test'
-import {refreshUntil} from "../delius/utils/refresh.js";
+import { refreshUntil } from '../delius/utils/refresh.js'
 
 export const login = async (page: Page) => {
     await page.goto(process.env.WORKFORCE_URL)

--- a/steps/workforce/login.ts
+++ b/steps/workforce/login.ts
@@ -1,4 +1,5 @@
 import { type Page, expect } from '@playwright/test'
+import {refreshUntil} from "../delius/utils/refresh.js";
 
 export const login = async (page: Page) => {
     await page.goto(process.env.WORKFORCE_URL)

--- a/steps/workforce/utils.ts
+++ b/steps/workforce/utils.ts
@@ -1,6 +1,6 @@
 import {Allocation} from "../../test-data/test-data.js";
 import { subDays, isBefore } from 'date-fns';
-import { parse } from 'date-fns/esm';
+import { parse } from 'date-fns';
 import {expect, Page} from "@playwright/test";
 import {doUntil, refreshUntil} from "../delius/utils/refresh.js";
 import {selectTeam} from "./allocations.js";

--- a/steps/workforce/utils.ts
+++ b/steps/workforce/utils.ts
@@ -1,3 +1,11 @@
+import {Allocation} from "../../test-data/test-data.js";
+import { subDays, isBefore } from 'date-fns';
+import { parse } from 'date-fns/esm';
+import {expect, Page} from "@playwright/test";
+import {doUntil, refreshUntil} from "../delius/utils/refresh.js";
+import {selectTeam} from "./allocations.js";
+import { login as workforceLogin } from '../../steps/workforce/login.js'
+
 const months = [
     'January',
     'February',
@@ -18,3 +26,70 @@ export const WorkforceDateFormat = (date: Date) => {
     const year = date.getFullYear()
     return `${day} ${month} ${year}`
 }
+
+export const allocateUnallocatedCasesWithinDateRange = async (page: Page, maxIterations: number, rangeDays:number, allocation: Allocation) => {
+    const today = new Date();
+    const fiveDaysAgo = subDays(today, rangeDays);
+
+    for (let i = 1; i <= maxIterations; i++) {
+        try {
+            console.log(`Running iteration ${i}`);
+
+            // Login to Manage Workforce and navigate @Unallocated Cases@
+            await workforceLogin(page);
+            await page.getByRole('button', {name: 'View unallocated cases'}).click();
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Unallocated cases.*/));
+
+            // Sort the Sentence Date Column to get the older cases first
+            await page.getByRole('button', {name: '▼ Sentence date ▲'}).click();
+
+            const dateText = await page.$eval(
+                '#main-content div.moj-scrollable-pane.govuk-\\!-margin-bottom-9 table tbody tr:first-child td:nth-child(3)',
+                (el) => el.textContent.trim()
+            );
+            const date = parse(dateText, 'dd MMMM yyyy', new Date());
+
+            if (isBefore(fiveDaysAgo, date)) {
+                console.log(`Date ${date} is 5 days or less before today's date. Stopping loop.`);
+                break;
+            }
+
+            const crn = await page.locator('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > span').textContent();
+            console.log(`Running iteration ${i} for ${crn} with Sentence DATE ${date}`);
+            await selectTeam(page, allocation.team);
+            await page.click('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > a');
+            await page.locator('a', {hasText: 'Continue'}).click();
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Choose practitioner.*/));
+
+            // Allocate to team/staff
+            await page
+                .locator('tr', {hasText: `${allocation.staff.firstName} ${allocation.staff.lastName}`})
+                .getByRole('radio')
+                .check();
+            await page.locator('button', {hasText: 'Continue'}).click();
+
+            // Confirm allocation
+            await expect(page).toHaveTitle(/.*Allocate to practitioner.*/);
+            await page.locator('a', {hasText: 'Continue'}).click();
+
+            // Review and submit allocation
+            await expect(page).toHaveTitle(/.*Review allocation instructions.*/);
+            await page.fill('#instructions', `Allocation for ${crn} completed by hmpps-end-to-end-tests`);
+            await page.locator('button', {hasText: 'Allocate Case'}).click();
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/));
+
+            await doUntil(
+                () => page.locator('a', {hasText: 'Sign out'}).click(),
+                () => expect(page).toHaveTitle(/.*HMPPS Digital Services - Sign in.*/)
+            )
+
+        } catch (error) {
+            console.error(`Error occurred in iteration ${i}: ${error}`);
+        } finally {
+            // Always clear cookies and storage to ensure a fresh start for the next iteration
+            await page.context().clearCookies();
+            window.localStorage.clear();
+            window.sessionStorage.clear();
+        }
+    }
+};

--- a/steps/workforce/utils.ts
+++ b/steps/workforce/utils.ts
@@ -1,9 +1,9 @@
-import {Allocation} from "../../test-data/test-data.js";
-import { subDays, isBefore } from 'date-fns';
-import { parse } from 'date-fns';
-import {expect, Page} from "@playwright/test";
-import {doUntil, refreshUntil} from "../delius/utils/refresh.js";
-import {selectTeam} from "./allocations.js";
+import { Allocation } from '../../test-data/test-data.js'
+import { subDays, isBefore } from 'date-fns'
+import { parse } from 'date-fns'
+import { expect, Page } from '@playwright/test'
+import { doUntil, refreshUntil } from '../delius/utils/refresh.js'
+import { selectTeam } from './allocations.js'
 import { login as workforceLogin } from '../../steps/workforce/login.js'
 
 const months = [
@@ -27,69 +27,75 @@ export const WorkforceDateFormat = (date: Date) => {
     return `${day} ${month} ${year}`
 }
 
-export const allocateUnallocatedCasesWithinDateRange = async (page: Page, maxIterations: number, rangeDays:number, allocation: Allocation) => {
-    const today = new Date();
-    const fiveDaysAgo = subDays(today, rangeDays);
+export const allocateUnallocatedCasesWithinDateRange = async (
+    page: Page,
+    maxIterations: number,
+    rangeDays: number,
+    allocation: Allocation
+) => {
+    const today = new Date()
+    const fiveDaysAgo = subDays(today, rangeDays)
 
     for (let i = 1; i <= maxIterations; i++) {
         try {
-            console.log(`Running iteration ${i}`);
+            console.log(`Running iteration ${i}`)
 
             // Login to Manage Workforce and navigate @Unallocated Cases@
-            await workforceLogin(page);
-            await page.getByRole('button', {name: 'View unallocated cases'}).click();
-            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Unallocated cases.*/));
+            await workforceLogin(page)
+            await page.getByRole('button', { name: 'View unallocated cases' }).click()
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Unallocated cases.*/))
 
             // Sort the Sentence Date Column to get the older cases first
-            await page.getByRole('button', {name: '▼ Sentence date ▲'}).click();
+            await page.getByRole('button', { name: '▼ Sentence date ▲' }).click()
 
             const dateText = await page.$eval(
                 '#main-content div.moj-scrollable-pane.govuk-\\!-margin-bottom-9 table tbody tr:first-child td:nth-child(3)',
-                (el) => el.textContent.trim()
-            );
-            const date = parse(dateText, 'dd MMMM yyyy', new Date());
+                el => el.textContent.trim()
+            )
+            const date = parse(dateText, 'dd MMMM yyyy', new Date())
 
             if (isBefore(fiveDaysAgo, date)) {
-                console.log(`Date ${date} is 5 days or less before today's date. Stopping loop.`);
-                break;
+                console.log(`Date ${date} is 5 days or less before today's date. Stopping loop.`)
+                break
             }
 
-            const crn = await page.locator('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > span').textContent();
-            console.log(`Running iteration ${i} for ${crn} with Sentence DATE ${date}`);
-            await selectTeam(page, allocation.team);
-            await page.click('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > a');
-            await page.locator('a', {hasText: 'Continue'}).click();
-            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Choose practitioner.*/));
+            const crn = await page
+                .locator('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > span')
+                .textContent()
+            console.log(`Running iteration ${i} for ${crn} with Sentence DATE ${date}`)
+            await selectTeam(page, allocation.team)
+            await page.click('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > a')
+            await page.locator('a', { hasText: 'Continue' }).click()
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Choose practitioner.*/))
 
             // Allocate to team/staff
             await page
-                .locator('tr', {hasText: `${allocation.staff.firstName} ${allocation.staff.lastName}`})
+                .locator('tr', { hasText: `${allocation.staff.firstName} ${allocation.staff.lastName}` })
                 .getByRole('radio')
-                .check();
-            await page.locator('button', {hasText: 'Continue'}).click();
+                .check()
+            await page.locator('button', { hasText: 'Continue' }).click()
 
             // Confirm allocation
-            await expect(page).toHaveTitle(/.*Allocate to practitioner.*/);
-            await page.locator('a', {hasText: 'Continue'}).click();
+            await expect(page).toHaveTitle(/.*Allocate to practitioner.*/)
+            await page.locator('a', { hasText: 'Continue' }).click()
 
             // Review and submit allocation
-            await expect(page).toHaveTitle(/.*Review allocation instructions.*/);
-            await page.fill('#instructions', `Allocation for ${crn} completed by hmpps-end-to-end-tests`);
-            await page.locator('button', {hasText: 'Allocate Case'}).click();
-            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/));
+            await expect(page).toHaveTitle(/.*Review allocation instructions.*/)
+            await page.fill('#instructions', `Allocation for ${crn} completed by hmpps-end-to-end-tests`)
+            await page.locator('button', { hasText: 'Allocate Case' }).click()
+            await refreshUntil(page, () => expect(page).toHaveTitle(/.*Case allocated | Manage a workforce.*/))
 
             await doUntil(
-                () => page.locator('a', {hasText: 'Sign out'}).click(),
+                () => page.locator('a', { hasText: 'Sign out' }).click(),
                 () => expect(page).toHaveTitle(/.*HMPPS Digital Services - Sign in.*/)
             )
-
         } catch (error) {
-            console.error(`Error occurred in iteration ${i}: ${error}`);
+            console.error(`Error occurred in iteration ${i}: ${error}`)
         } finally {
             // Always clear cookies and storage to ensure a fresh start for the next iteration
-            await page.context().clearCookies();
-            window.localStorage.clear();
-            window.sessionStorage.clear();
+            await page.context().clearCookies()
+            window.localStorage.clear()
+            window.sessionStorage.clear()
         }
     }
-};
+}

--- a/test-data/environments/test.ts
+++ b/test-data/environments/test.ts
@@ -24,6 +24,12 @@ export const testEnvironmentData: TestData = {
             firstName: 'Derek',
             lastName: 'Pint',
         },
+        genericStaff: {
+            name: 'Cobio, Titus ZZ (NPS - PSO)',
+            firstName: 'Titus',
+            lastName: 'Cobio',
+        },
+
         approvedPremisesKeyWorker: {
             name: 'Kshlerin, Barry (CRC - Additional Grade)',
             firstName: 'Barry',
@@ -45,6 +51,10 @@ export const testEnvironmentData: TestData = {
         approvedPremisesTestTeam: {
             name: 'Lancashire PICS',
             provider: 'NPS North West',
+        },
+        genericTeam: {
+            name: 'OMU A',
+            provider: 'NPS North East',
         },
     },
     sentencedPrisoner: {

--- a/tests/approved-premises-and-delius/create-booking.spec.ts
+++ b/tests/approved-premises-and-delius/create-booking.spec.ts
@@ -33,7 +33,10 @@ test('Create an approved premises booking', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     // And I create an offender
-    const crn: string = await createOffender(page, { person, providerName: data.teams.approvedPremisesTestTeam.provider })
+    const crn: string = await createOffender(page, {
+        person,
+        providerName: data.teams.approvedPremisesTestTeam.provider,
+    })
     // And I create an event in nDelius
     await createCustodialEvent(page, { crn, allocation: { team: data.teams.approvedPremisesTestTeam } })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)

--- a/tests/approved-premises-and-delius/create-booking.spec.ts
+++ b/tests/approved-premises-and-delius/create-booking.spec.ts
@@ -33,7 +33,7 @@ test('Create an approved premises booking', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     // And I create an offender
-    const crn: string = await createOffender(page, { person, providerName: data.teams.genericTeam.provider })
+    const crn: string = await createOffender(page, { person, providerName: data.teams.approvedPremisesTestTeam.provider })
     // And I create an event in nDelius
     await createCustodialEvent(page, { crn, allocation: { team: data.teams.approvedPremisesTestTeam } })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)

--- a/tests/approved-premises-and-delius/create-booking.spec.ts
+++ b/tests/approved-premises-and-delius/create-booking.spec.ts
@@ -26,15 +26,16 @@ import { findOffenderByCRN } from '../../steps/delius/offender/find-offender.js'
 const nomisIds = []
 
 test('Create an approved premises booking', async ({ page }) => {
+    test.skip()
     test.slow() // increase the timeout - Delius/OASys/AP Applications/Approved premises can take a few minutes
     // Given I login in to NDelius
     await hmppsLogin(page)
     await deliusLogin(page)
     const person = deliusPerson()
     // And I create an offender
-    const crn: string = await createOffender(page, { person, providerName: data.teams.allocationsTestTeam.provider })
+    const crn: string = await createOffender(page, { person, providerName: data.teams.genericTeam.provider })
     // And I create an event in nDelius
-    await createCustodialEvent(page, { crn, allocation: { team: data.teams.allocationsTestTeam } })
+    await createCustodialEvent(page, { crn, allocation: { team: data.teams.approvedPremisesTestTeam } })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
     const { nomisId } = await createAndBookPrisoner(page, crn, person)
     nomisIds.push(nomisId)

--- a/tests/make-recall-decisions-and-delius/recommend-a-recall.spec.ts
+++ b/tests/make-recall-decisions-and-delius/recommend-a-recall.spec.ts
@@ -21,6 +21,7 @@ import { createContact } from '../../steps/delius/contact/create-contact.js'
 import { Yesterday } from '../../steps/delius/utils/date-time.js'
 import { verifyContacts } from '../../steps/delius/contact/find-contacts.js'
 import { contact } from '../../steps/delius/utils/contact.js'
+import {data} from "../../test-data/test-data.js";
 dotenv.config() // read environment variables into process.env
 
 test('Make a recall recommendation', async ({ page }) => {
@@ -28,7 +29,7 @@ test('Make a recall recommendation', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     const name = person.firstName + ' ' + person.lastName
-    const crn = await createOffender(page, { person })
+    const crn = await createOffender(page, { person, providerName: data.teams.genericTeam.provider })
 
     // And I create an Address
     const address = buildAddress()
@@ -44,7 +45,7 @@ test('Make a recall recommendation', async ({ page }) => {
     await createContact(page, crn, contactDetails)
 
     // And I create a Custodial Event
-    await createCustodialEvent(page, { crn })
+    await createCustodialEvent(page, { crn, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
 
     // And I create a Release
     await createRelease(page, crn)

--- a/tests/make-recall-decisions-and-delius/recommend-a-recall.spec.ts
+++ b/tests/make-recall-decisions-and-delius/recommend-a-recall.spec.ts
@@ -21,7 +21,7 @@ import { createContact } from '../../steps/delius/contact/create-contact.js'
 import { Yesterday } from '../../steps/delius/utils/date-time.js'
 import { verifyContacts } from '../../steps/delius/contact/find-contacts.js'
 import { contact } from '../../steps/delius/utils/contact.js'
-import {data} from "../../test-data/test-data.js";
+import { data } from '../../test-data/test-data.js'
 dotenv.config() // read environment variables into process.env
 
 test('Make a recall recommendation', async ({ page }) => {
@@ -45,7 +45,10 @@ test('Make a recall recommendation', async ({ page }) => {
     await createContact(page, crn, contactDetails)
 
     // And I create a Custodial Event
-    await createCustodialEvent(page, { crn, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
+    await createCustodialEvent(page, {
+        crn,
+        allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
+    })
 
     // And I create a Release
     await createRelease(page, crn)

--- a/tests/person-search-index-from-delius/search-for-person.spec.ts
+++ b/tests/person-search-index-from-delius/search-for-person.spec.ts
@@ -38,8 +38,8 @@ test('Create and search for contacts', async ({ page }) => {
         relatesTo: `Person - ${person.firstName} ${person.lastName}`,
         date: LastMonth,
         allocation: {
-            team: data.teams.allocationsTestTeam,
-            staff: data.staff.allocationsTester2,
+            team: data.teams.genericTeam,
+            staff: data.staff.genericStaff,
         },
     })
     await createContact(page, crn, {
@@ -48,8 +48,8 @@ test('Create and search for contacts', async ({ page }) => {
         relatesTo: `Person - ${person.firstName} ${person.lastName}`,
         date: Yesterday,
         allocation: {
-            team: data.teams.allocationsTestTeam,
-            staff: data.staff.allocationsTester2,
+            team: data.teams.genericTeam,
+            staff: data.staff.genericStaff,
         },
     })
     await createContact(page, crn, {
@@ -58,8 +58,8 @@ test('Create and search for contacts', async ({ page }) => {
         relatesTo: `Person - ${person.firstName} ${person.lastName}`,
         date: new Date(),
         allocation: {
-            team: data.teams.allocationsTestTeam,
-            staff: data.staff.allocationsTester2,
+            team: data.teams.genericTeam,
+            staff: data.staff.genericStaff,
         },
     })
     await createContact(page, crn, {
@@ -68,8 +68,8 @@ test('Create and search for contacts', async ({ page }) => {
         relatesTo: `Person - ${person.firstName} ${person.lastName}`,
         date: Tomorrow,
         allocation: {
-            team: data.teams.allocationsTestTeam,
-            staff: data.staff.allocationsTester2,
+            team: data.teams.genericTeam,
+            staff: data.staff.genericStaff,
         },
     })
 

--- a/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
+++ b/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
@@ -18,7 +18,11 @@ test('Create a short format pre-sentence report', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
-    const event = await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
+    const event = await createEvent(page, {
+        crn,
+        event: data.events.adjournedForFastPreSentenceReport,
+        allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
+    })
     await page.locator('input', { hasText: 'Save' }).click()
     await findCourtReport(page, crn)
     await createDocumentFromTemplate(page, data.documentTemplates.shortFormatPreSentenceReport)

--- a/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
+++ b/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
@@ -18,7 +18,7 @@ test('Create a short format pre-sentence report', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
-    const event = await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport })
+    const event = await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
     await page.locator('input', { hasText: 'Save' }).click()
     await findCourtReport(page, crn)
     await createDocumentFromTemplate(page, data.documentTemplates.shortFormatPreSentenceReport)

--- a/tests/prison-case-notes-to-probation/case-notes.spec.ts
+++ b/tests/prison-case-notes-to-probation/case-notes.spec.ts
@@ -8,6 +8,7 @@ import { createOffender } from '../../steps/delius/offender/create-offender.js'
 import { createCustodialEvent } from '../../steps/delius/event/create-event.js'
 import { deliusPerson } from '../../steps/delius/utils/person.js'
 import { createAndBookPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api.js'
+import {data} from "../../test-data/test-data.js";
 
 const nomisIds = []
 
@@ -16,7 +17,7 @@ test('Create a new case note', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
-    const event = await createCustodialEvent(page, { crn })
+    const event = await createCustodialEvent(page, { crn, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
 
     // And a corresponding person and booking in NOMIS
     const { nomisId } = await createAndBookPrisoner(page, crn, person)

--- a/tests/prison-case-notes-to-probation/case-notes.spec.ts
+++ b/tests/prison-case-notes-to-probation/case-notes.spec.ts
@@ -8,7 +8,7 @@ import { createOffender } from '../../steps/delius/offender/create-offender.js'
 import { createCustodialEvent } from '../../steps/delius/event/create-event.js'
 import { deliusPerson } from '../../steps/delius/utils/person.js'
 import { createAndBookPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api.js'
-import {data} from "../../test-data/test-data.js";
+import { data } from '../../test-data/test-data.js'
 
 const nomisIds = []
 
@@ -17,7 +17,10 @@ test('Create a new case note', async ({ page }) => {
     await deliusLogin(page)
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
-    const event = await createCustodialEvent(page, { crn, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
+    const event = await createCustodialEvent(page, {
+        crn,
+        allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
+    })
 
     // And a corresponding person and booking in NOMIS
     const { nomisId } = await createAndBookPrisoner(page, crn, person)

--- a/tests/risk-assessment-scores-to-delius/create-standalone-rsr-assessment.spec.ts
+++ b/tests/risk-assessment-scores-to-delius/create-standalone-rsr-assessment.spec.ts
@@ -22,7 +22,11 @@ test('Create a standalone RSR Assessment', async ({ page }) => {
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
     // And I create an event in nDelius
-    await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
+    await createEvent(page, {
+        crn,
+        event: data.events.adjournedForFastPreSentenceReport,
+        allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
+    })
     // Given I log in to OASys as a "OASYS_T2_LOGIN_USER" user
     await oasysLogin(page, UserType.RSR)
     // And I select "Warwickshire" from Choose Provider Establishment

--- a/tests/risk-assessment-scores-to-delius/create-standalone-rsr-assessment.spec.ts
+++ b/tests/risk-assessment-scores-to-delius/create-standalone-rsr-assessment.spec.ts
@@ -22,7 +22,7 @@ test('Create a standalone RSR Assessment', async ({ page }) => {
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
     // And I create an event in nDelius
-    await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport })
+    await createEvent(page, { crn, event: data.events.adjournedForFastPreSentenceReport, allocation: {team: data.teams.genericTeam, staff: data.staff.genericStaff} })
     // Given I log in to OASys as a "OASYS_T2_LOGIN_USER" user
     await oasysLogin(page, UserType.RSR)
     // And I select "Warwickshire" from Choose Provider Establishment

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -13,6 +13,7 @@ import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
 import { submitUPWAssessment } from '../../steps/unpaidwork/task-list.js'
 import { completeAllUPWSections } from '../../steps/unpaidwork/complete-all-upw-sections.js'
 import { format } from 'date-fns'
+import {doUntil} from "../../steps/delius/utils/refresh.js";
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
@@ -48,11 +49,13 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     await page.locator('a', { hasText: 'Document List' }).click()
     await page.locator('[title="Button to search for Documents"]').click()
 
-    // await page.locator('#documentListForm\\:j_id_id70').click()
-    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
-        'CP/UPW Assessment',
-        { timeout: 15000 }
+    await page.locator('a', { hasText: 'Document List' }).click()
+
+    await doUntil(
+        () => page.getByRole('button', {name: 'Search'}).click(),
+        () => expect(page.locator('table')).toContainText('CP/UPW Assessment')
     )
+
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
         format(new Date(), 'dd/MM/yyyy')
     )

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -47,9 +47,6 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
 
     // Then the document appears in the Delius document list
     await page.locator('a', { hasText: 'Document List' }).click()
-    await page.locator('[title="Button to search for Documents"]').click()
-
-    await page.locator('a', { hasText: 'Document List' }).click()
 
     await doUntil(
         () => page.getByRole('button', { name: 'Search' }).click(),

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -43,7 +43,7 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     // Then the document appears in the Delius document list
     await page.locator('a', { hasText: 'Document List' }).click()
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
-        'CP/UPW Assessment'
+        'CP/UPW Assessment', { timeout: 15000 }
     )
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
         format(new Date(), 'dd/MM/yyyy')

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -42,6 +42,9 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
 
     // Then the document appears in the Delius document list
     await page.locator('a', { hasText: 'Document List' }).click()
+    await page.locator('[title="Button to search for Documents"]').click()
+
+    // await page.locator('#documentListForm\\:j_id_id70').click()
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
         'CP/UPW Assessment', { timeout: 15000 }
     )

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -13,7 +13,7 @@ import { login as unpaidWorkLogin } from '../../steps/unpaidwork/login.js'
 import { submitUPWAssessment } from '../../steps/unpaidwork/task-list.js'
 import { completeAllUPWSections } from '../../steps/unpaidwork/complete-all-upw-sections.js'
 import { format } from 'date-fns'
-import {doUntil} from "../../steps/delius/utils/refresh.js";
+import { doUntil } from '../../steps/delius/utils/refresh.js'
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
@@ -52,7 +52,7 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     await page.locator('a', { hasText: 'Document List' }).click()
 
     await doUntil(
-        () => page.getByRole('button', {name: 'Search'}).click(),
+        () => page.getByRole('button', { name: 'Search' }).click(),
         () => expect(page.locator('table')).toContainText('CP/UPW Assessment')
     )
 

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -26,7 +26,11 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
         allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
     })
     // And I add a requirement for this event with the type called "unpaid work"
-    await createRequirementForEvent(page, { crn, requirement: data.requirements.unpaidWork, team: data.teams.genericTeam })
+    await createRequirementForEvent(page, {
+        crn,
+        requirement: data.requirements.unpaidWork,
+        team: data.teams.genericTeam,
+    })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
     const { nomisId } = await createAndBookPrisoner(page, crn, person)
     nomisIds.push(nomisId)
@@ -46,7 +50,8 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
 
     // await page.locator('#documentListForm\\:j_id_id70').click()
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
-        'CP/UPW Assessment', { timeout: 15000 }
+        'CP/UPW Assessment',
+        { timeout: 15000 }
     )
     await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
         format(new Date(), 'dd/MM/yyyy')

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -23,10 +23,10 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
     // And I create Supervision Community Event in Delius
     await createCommunityEvent(page, {
         crn,
-        allocation: { team: data.teams.allocationsTestTeam, staff: data.staff.allocationsTester2 },
+        allocation: { team: data.teams.genericTeam, staff: data.staff.genericStaff },
     })
     // And I add a requirement for this event with the type called "unpaid work"
-    await createRequirementForEvent(page, { crn, requirement: data.requirements.unpaidWork })
+    await createRequirementForEvent(page, { crn, requirement: data.requirements.unpaidWork, team: data.teams.genericTeam })
     // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
     const { nomisId } = await createAndBookPrisoner(page, crn, person)
     nomisIds.push(nomisId)

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -116,18 +116,17 @@ test('Allocate previously-managed person', async ({ page }) => {
 //If any test fails, allocate in Delius to prevent allocations lists continually build up
 test.afterAll(async () => {
     if (crns.length > 0) {
-        const browser = await chromium.launch()
-        const page = await browser.newPage()
+        const browser = await chromium.launch();
+        const page = await browser.newPage();
 
-        try {
-            for (const crn of crns) {
-                await internalTransfer(page, { crn, allocation: anotherPractitioner })
+        for (const crn of crns) {
+            try {
+                await internalTransfer(page, {crn, allocation: anotherPractitioner});
+            } catch (error) {
+                console.error(`Error occurred during internal transfer: ${error}`);
             }
-        } catch (error) {
-            console.error(`Error occurred during internal transfer: ${error}`)
-        } finally {
-            await page.close()
-            await browser.close()
         }
+        await page.close();
+        await browser.close();
     }
-})
+});

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -10,7 +10,7 @@ import { internalTransfer } from '../../steps/delius/transfer/internal-transfer.
 import { terminateEvent } from '../../steps/delius/event/terminate-events.js'
 import { contact } from '../../steps/delius/utils/contact.js'
 import { Allocation, data } from '../../test-data/test-data.js'
-import {chromium, test} from '@playwright/test'
+import { chromium, test } from '@playwright/test'
 import { createInitialAppointment } from '../../steps/delius/contact/create-contact.js'
 
 test.beforeEach(async ({ page }) => {
@@ -22,14 +22,14 @@ const practitioner: Allocation = { staff: data.staff.allocationsTester1, team: d
 // and another staff member in the same team, for currently/previously allocated cases:
 const anotherPractitioner: Allocation = { staff: data.staff.allocationsTester2, team: data.teams.allocationsTestTeam }
 // get all the crns
-const crns: string[] = [];
+const crns: string[] = []
 
 const successful = async (crn: string): Promise<void> => {
-    const index = crns.indexOf(crn);
+    const index = crns.indexOf(crn)
     if (index > -1) {
-        crns.splice(index, 1);
+        crns.splice(index, 1)
     }
-};
+}
 
 test('Allocate new person', async ({ page }) => {
     // Given a new person in Delius, with an unallocated event and requirement in the allocations testing team
@@ -116,18 +116,18 @@ test('Allocate previously-managed person', async ({ page }) => {
 //If any test fails, allocate in Delius to prevent allocations lists continually build up
 test.afterAll(async () => {
     if (crns.length > 0) {
-        const browser = await chromium.launch();
-        const page = await browser.newPage();
+        const browser = await chromium.launch()
+        const page = await browser.newPage()
 
         try {
             for (const crn of crns) {
-                await internalTransfer(page, { crn, allocation: anotherPractitioner });
+                await internalTransfer(page, { crn, allocation: anotherPractitioner })
             }
         } catch (error) {
-            console.error(`Error occurred during internal transfer: ${error}`);
+            console.error(`Error occurred during internal transfer: ${error}`)
         } finally {
-            await page.close();
-            await browser.close();
+            await page.close()
+            await browser.close()
         }
     }
-});
+})

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -116,17 +116,17 @@ test('Allocate previously-managed person', async ({ page }) => {
 //If any test fails, allocate in Delius to prevent allocations lists continually build up
 test.afterAll(async () => {
     if (crns.length > 0) {
-        const browser = await chromium.launch();
-        const page = await browser.newPage();
+        const browser = await chromium.launch()
+        const page = await browser.newPage()
 
         for (const crn of crns) {
             try {
-                await internalTransfer(page, {crn, allocation: anotherPractitioner});
+                await internalTransfer(page, { crn, allocation: anotherPractitioner })
             } catch (error) {
-                console.error(`Error occurred during internal transfer: ${error}`);
+                console.error(`Error occurred during internal transfer: ${error}`)
             }
         }
-        await page.close();
-        await browser.close();
+        await page.close()
+        await browser.close()
     }
-});
+})


### PR DESCRIPTION


- 1. The 'RSR-score' test related code has been amended and now correctly extracts the rsr score, resolving previous issues with this test.

- 2. A util Script has been added to allocate the unallocated cases in Workforce front-end. This is to prevent a build-up of unallocated cases caused by tests from other teams, which can cause the tests to fail. The script makes it easy to allocate the unallocated cases and bring the total number down, ensuring smooth running of the tests.

- 3. The random selection of Providers and team has been removed, which was causing too much build up of unallocated cases in Workforce and causing the tests to fail.

- 4. An extra locator has been added to the "start-recommendation" test to verify the Licence Condition, which ensures that the test is not flaky.

- 5. The create contact date, start time, and end time have been changed to sysDate + 1 day to ensure the tests are more stable.

- 6. Code has been added to automatically allocate cases in Delius in case allocation tests fail, helping to ensure that tests are not blocked by unallocated cases.

- 7. The tests now include the 'data.teams.genericTeam' and 'genericStaff' parameters, which can be used in case of generic teams and staff requirements.

- 8. The UPW tests have been amended to handle Delius behavior where searching for the documents is required at times and not at other times.

- 9. Other minor code changes have been made to make the test suite more stable.