### PR TITLE
Fix failing tests whilst creating contact with a start date on public holidays

### DIFF
--- a/steps/delius/contact/create-contact.ts
+++ b/steps/delius/contact/create-contact.ts
@@ -31,8 +31,20 @@ export const createContact = async (page: Page, crn: string, options: Contact) =
     await selectOptionAndWait(page, '#addContactForm\\:TransferToOfficer', options.allocation?.staff?.name)
     await doUntil(
         () => page.locator('#addContactForm\\:saveButton').click(),
-        () => expect(page).toHaveTitle(/Contact List/)
-    )
+        async () => {
+            try {
+                await expect(page).toHaveTitle(/Contact List/)
+            } catch (error) {
+                await page.locator('[class$="prompt-warning"]').first()
+            }
+        }
+    );
+
+    if (await page.title() !== 'Contact List') {
+        await page.locator('[value="Confirm"]').click();
+    }
+
+    await expect(page).toHaveTitle(/Contact List/)
 }
 
 export const createInitialAppointment = async (page: Page, crn: string, eventNumber: string, team: Team = null) =>

--- a/steps/delius/contact/create-contact.ts
+++ b/steps/delius/contact/create-contact.ts
@@ -38,10 +38,10 @@ export const createContact = async (page: Page, crn: string, options: Contact) =
                 await page.locator('[class$="prompt-warning"]').first()
             }
         }
-    );
+    )
 
-    if (await page.title() !== 'Contact List') {
-        await page.locator('[value="Confirm"]').click();
+    if ((await page.title()) !== 'Contact List') {
+        await page.locator('[value="Confirm"]').click()
     }
 
     await expect(page).toHaveTitle(/Contact List/)


### PR DESCRIPTION
Code has been implemented to handle all types of dates, including past, present, and future dates. As a result, when a warning message appears, the code will now automatically confirm and redirect to the 'Contact List' page. This update was necessary to address the issue of failing tests that occurred today.