### PR TITLE
PI-985 - Fixed failing allocations tests and amendments to the auto-allocation script

### DIFF
--- a/steps/workforce/utils.ts
+++ b/steps/workforce/utils.ts
@@ -62,7 +62,7 @@ export const allocateUnallocatedCasesWithinDateRange = async (
             const crn = await page
                 .locator('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > span')
                 .textContent()
-            console.log(`Running iteration ${i} for ${crn} with Sentence DATE ${date}`)
+            console.log(`Allocating Case ${i} for ${crn} with Sentence DATE ${date}`)
             await selectTeam(page, allocation.team)
             await page.click('div > table > tbody > tr:nth-child(1) > td:nth-child(1) > a')
             await page.locator('a', { hasText: 'Continue' }).click()
@@ -94,8 +94,6 @@ export const allocateUnallocatedCasesWithinDateRange = async (
         } finally {
             // Always clear cookies and storage to ensure a fresh start for the next iteration
             await page.context().clearCookies()
-            window.localStorage.clear()
-            window.sessionStorage.clear()
         }
     }
 }

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -10,9 +10,8 @@ import { internalTransfer } from '../../steps/delius/transfer/internal-transfer.
 import { terminateEvent } from '../../steps/delius/event/terminate-events.js'
 import { contact } from '../../steps/delius/utils/contact.js'
 import { Allocation, data } from '../../test-data/test-data.js'
-import {chromium, Page, test} from '@playwright/test'
+import {chromium, test} from '@playwright/test'
 import { createInitialAppointment } from '../../steps/delius/contact/create-contact.js'
-import {allocateUnallocatedCasesWithinDateRange} from "../../steps/workforce/utils.js";
 
 test.beforeEach(async ({ page }) => {
     await login(page)

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -10,8 +10,9 @@ import { internalTransfer } from '../../steps/delius/transfer/internal-transfer.
 import { terminateEvent } from '../../steps/delius/event/terminate-events.js'
 import { contact } from '../../steps/delius/utils/contact.js'
 import { Allocation, data } from '../../test-data/test-data.js'
-import { chromium, test } from '@playwright/test'
+import {chromium, Page, test} from '@playwright/test'
 import { createInitialAppointment } from '../../steps/delius/contact/create-contact.js'
+import {allocateUnallocatedCasesWithinDateRange} from "../../steps/workforce/utils.js";
 
 test.beforeEach(async ({ page }) => {
     await login(page)
@@ -32,6 +33,7 @@ const successful = async (crn: string): Promise<void> => {
 }
 
 test('Allocate new person', async ({ page }) => {
+    test.slow()
     // Given a new person in Delius, with an unallocated event and requirement in the allocations testing team
     const crn = await createOffender(page, { providerName: data.teams.allocationsTestTeam.provider })
     crns.push(crn)
@@ -61,6 +63,7 @@ test('Allocate new person', async ({ page }) => {
 })
 
 test('Allocate currently-managed person', async ({ page }) => {
+    test.slow()
     // Given an existing person in Delius, with a currently allocated un-sentenced event
     const crn = await createOffender(page, { providerName: anotherPractitioner.team.provider })
     crns.push(crn)
@@ -86,6 +89,7 @@ test('Allocate currently-managed person', async ({ page }) => {
 })
 
 test('Allocate previously-managed person', async ({ page }) => {
+    test.slow()
     // Given an existing person in Delius, with a previously allocated (now terminated) community event
     const crn = await createOffender(page, { providerName: data.teams.allocationsTestTeam.provider })
     crns.push(crn)
@@ -115,6 +119,7 @@ test('Allocate previously-managed person', async ({ page }) => {
 
 //If any test fails, allocate in Delius to prevent allocations lists continually build up
 test.afterAll(async () => {
+    test.slow()
     if (crns.length > 0) {
         const browser = await chromium.launch()
         const page = await browser.newPage()

--- a/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
+++ b/tests/workforce-allocations-to-delius/allocate-new-person.spec.ts
@@ -10,7 +10,7 @@ import { internalTransfer } from '../../steps/delius/transfer/internal-transfer.
 import { terminateEvent } from '../../steps/delius/event/terminate-events.js'
 import { contact } from '../../steps/delius/utils/contact.js'
 import { Allocation, data } from '../../test-data/test-data.js'
-import {chromium, test} from '@playwright/test'
+import { chromium, test } from '@playwright/test'
 import { createInitialAppointment } from '../../steps/delius/contact/create-contact.js'
 
 test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
The previous PR brought about modifications to the automation test code, enabling it to handle instances where an allocation test fails, leaving a CRN unallocated in the workforce-dev environment. If a test fails, the code will automatically allocate the unallocated CRN in Delius by retrieving the associated CRN with the failed test. This means that whether an allocation test passes and successfully allocates a case in workforce-dev, or a test fails and an unallocated case is left in workforce-dev, the system will automatically allocate the case to Delius. However, if a test fails, it must exceed the preset limit of 180 seconds to trigger the allocation process in Delius. As such, we have incorporated 'slow' statements into the code to prevent test failures that require more than 180 seconds to execute.