### PR TITLE
PI-1089 - Add test for verifying referral cancellation by Probation Practitioner and its reflection in Delius

### DIFF
--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -56,7 +56,7 @@ export async function verifyContact(page: Page, contact: Contact, isNSIContact =
     }
 }
 
-export const navigateToNSIContactDetails = async (page: Page, crn: string, terminatedEvent?: boolean) => {
+export const navigateToNSIContactDetails = async (page: Page, crn: string, terminatedEvent: boolean = false) => {
     await findOffenderByCRN(page, crn);
     await page.click('#linkNavigation2EventList');
     await expect(page).toHaveTitle(/Events/);

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -56,27 +56,26 @@ export async function verifyContact(page: Page, contact: Contact, isNSIContact =
     }
 }
 
-export const navigateToNSIContactDetails = async (page: Page, crn: string, includeTerminatedNSI: boolean = false) => {
-        await navigateToNSIDetails(page, crn, includeTerminatedNSI)
-        await page.locator('[value="Contact List for this NSI"]').click();
-        await expect(page).toHaveTitle(/Contact List for NSIs/);
-};
+export const navigateToNSIContactDetails = async (page: Page, crn: string, includeTerminatedNSI = false) => {
+    await navigateToNSIDetails(page, crn, includeTerminatedNSI)
+    await page.locator('[value="Contact List for this NSI"]').click()
+    await expect(page).toHaveTitle(/Contact List for NSIs/)
+}
 
-export const navigateToNSIDetails = async (page: Page, crn: string, includeTerminatedNSI: boolean = false) => {
-    await findOffenderByCRN(page, crn);
-    await page.click('#linkNavigation2EventList');
-    await expect(page).toHaveTitle(/Events/);
-    await page.locator('[title="View event"]', { hasText: 'View' }).click();
-    await expect(page).toHaveTitle(/Event Details/);
-    await page.click('#linkNavigation3EventNsi');
-    await expect(page).toHaveTitle(/Non Statutory Intervention List/);
+export const navigateToNSIDetails = async (page: Page, crn: string, includeTerminatedNSI = false) => {
+    await findOffenderByCRN(page, crn)
+    await page.click('#linkNavigation2EventList')
+    await expect(page).toHaveTitle(/Events/)
+    await page.locator('[title="View event"]', { hasText: 'View' }).click()
+    await expect(page).toHaveTitle(/Event Details/)
+    await page.click('#linkNavigation3EventNsi')
+    await expect(page).toHaveTitle(/Non Statutory Intervention List/)
     if (includeTerminatedNSI) {
-        await page.locator('#nsiListForm\\:ShowTerminated').selectOption({ label: 'Yes' });
+        await page.locator('#nsiListForm\\:ShowTerminated').selectOption({ label: 'Yes' })
     }
-    await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click();
-    await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details');
-};
-
+    await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click()
+    await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details')
+}
 
 export const rescheduleSupplierAssessmentAppointment = async (
     page: Page,

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -55,21 +55,6 @@ export async function verifyContact(page: Page, contact: Contact, isNSIContact =
         )
     }
 }
-//
-// export const navigateToNSIContactDetails = async (page: Page, crn: string) => {
-//     await findOffenderByCRN(page, crn)
-//     await page.click('#linkNavigation2EventList')
-//     await expect(page).toHaveTitle(/Events/)
-//     await page.locator('[title="View event"]', { hasText: 'View' }).click()
-//     await expect(page).toHaveTitle(/Event Details/)
-//     await page.click('#linkNavigation3EventNsi')
-//     await expect(page).toHaveTitle(/Non Statutory Intervention List/)
-//     await page.locator('main[role="main"]').locator('a', { hasText: 'view' }).click()
-//     await expect(page).toHaveTitle(/Non Statutory Intervention Details/)
-//     await page.locator('[value="Contact List for this NSI"]').click()
-//     await expect(page).toHaveTitle(/Contact List for NSIs/)
-// }
-
 
 export const navigateToNSIContactDetails = async (page: Page, crn: string, terminatedEvent?: boolean) => {
     await findOffenderByCRN(page, crn);
@@ -91,7 +76,6 @@ export const navigateToNSIContactDetails = async (page: Page, crn: string, termi
         await expect(page).toHaveTitle(/Contact List for NSIs/);
     }
 };
-
 
 export const rescheduleSupplierAssessmentAppointment = async (
     page: Page,

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -55,20 +55,43 @@ export async function verifyContact(page: Page, contact: Contact, isNSIContact =
         )
     }
 }
+//
+// export const navigateToNSIContactDetails = async (page: Page, crn: string) => {
+//     await findOffenderByCRN(page, crn)
+//     await page.click('#linkNavigation2EventList')
+//     await expect(page).toHaveTitle(/Events/)
+//     await page.locator('[title="View event"]', { hasText: 'View' }).click()
+//     await expect(page).toHaveTitle(/Event Details/)
+//     await page.click('#linkNavigation3EventNsi')
+//     await expect(page).toHaveTitle(/Non Statutory Intervention List/)
+//     await page.locator('main[role="main"]').locator('a', { hasText: 'view' }).click()
+//     await expect(page).toHaveTitle(/Non Statutory Intervention Details/)
+//     await page.locator('[value="Contact List for this NSI"]').click()
+//     await expect(page).toHaveTitle(/Contact List for NSIs/)
+// }
 
-export const navigateToNSIContactDetails = async (page: Page, crn: string) => {
-    await findOffenderByCRN(page, crn)
-    await page.click('#linkNavigation2EventList')
-    await expect(page).toHaveTitle(/Events/)
-    await page.locator('[title="View event"]', { hasText: 'View' }).click()
-    await expect(page).toHaveTitle(/Event Details/)
-    await page.click('#linkNavigation3EventNsi')
-    await expect(page).toHaveTitle(/Non Statutory Intervention List/)
-    await page.locator('main[role="main"]').locator('a', { hasText: 'view' }).click()
-    await expect(page).toHaveTitle(/Non Statutory Intervention Details/)
-    await page.locator('[value="Contact List for this NSI"]').click()
-    await expect(page).toHaveTitle(/Contact List for NSIs/)
-}
+
+export const navigateToNSIContactDetails = async (page: Page, crn: string, terminatedEvent?: boolean) => {
+    await findOffenderByCRN(page, crn);
+    await page.click('#linkNavigation2EventList');
+    await expect(page).toHaveTitle(/Events/);
+    await page.locator('[title="View event"]', { hasText: 'View' }).click();
+    await expect(page).toHaveTitle(/Event Details/);
+    await page.click('#linkNavigation3EventNsi');
+
+    if (terminatedEvent) {
+        await page.locator('#nsiListForm\\:ShowTerminated').selectOption({ label: 'Yes' });
+        await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click();
+        await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details');
+    } else {
+        await expect(page).toHaveTitle(/Non Statutory Intervention List/);
+        await page.locator('main[role="main"]').locator('a', { hasText: 'view' }).click();
+        await expect(page).toHaveTitle(/Non Statutory Intervention Details/);
+        await page.locator('[value="Contact List for this NSI"]').click();
+        await expect(page).toHaveTitle(/Contact List for NSIs/);
+    }
+};
+
 
 export const rescheduleSupplierAssessmentAppointment = async (
     page: Page,

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -56,26 +56,27 @@ export async function verifyContact(page: Page, contact: Contact, isNSIContact =
     }
 }
 
-export const navigateToNSIContactDetails = async (page: Page, crn: string, terminatedEvent: boolean = false) => {
+export const navigateToNSIContactDetails = async (page: Page, crn: string, includeTerminatedNSI: boolean = false) => {
+        await navigateToNSIDetails(page, crn, includeTerminatedNSI)
+        await page.locator('[value="Contact List for this NSI"]').click();
+        await expect(page).toHaveTitle(/Contact List for NSIs/);
+};
+
+export const navigateToNSIDetails = async (page: Page, crn: string, includeTerminatedNSI: boolean = false) => {
     await findOffenderByCRN(page, crn);
     await page.click('#linkNavigation2EventList');
     await expect(page).toHaveTitle(/Events/);
     await page.locator('[title="View event"]', { hasText: 'View' }).click();
     await expect(page).toHaveTitle(/Event Details/);
     await page.click('#linkNavigation3EventNsi');
-
-    if (terminatedEvent) {
+    await expect(page).toHaveTitle(/Non Statutory Intervention List/);
+    if (includeTerminatedNSI) {
         await page.locator('#nsiListForm\\:ShowTerminated').selectOption({ label: 'Yes' });
-        await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click();
-        await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details');
-    } else {
-        await expect(page).toHaveTitle(/Non Statutory Intervention List/);
-        await page.locator('main[role="main"]').locator('a', { hasText: 'view' }).click();
-        await expect(page).toHaveTitle(/Non Statutory Intervention Details/);
-        await page.locator('[value="Contact List for this NSI"]').click();
-        await expect(page).toHaveTitle(/Contact List for NSIs/);
     }
+    await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click();
+    await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details');
 };
+
 
 export const rescheduleSupplierAssessmentAppointment = async (
     page: Page,

--- a/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
+++ b/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
@@ -12,7 +12,7 @@ import {
 import { createSupplierAssessmentAppointment } from '../../steps/referandmonitor/appointment.js'
 import { data } from '../../test-data/test-data.js'
 import {
-    navigateToNSIContactDetails,
+    navigateToNSIContactDetails, navigateToNSIDetails,
     rescheduleSupplierAssessmentAppointment,
     updateSAAppointmentLocation,
     verifyContact,
@@ -417,6 +417,6 @@ test('Verify Referral Cancellation by Probation Practitioner and its Reflection 
 
     // Verify the referral cancellation should reflect in Delius
     await loginDelius(page)
-    await navigateToNSIContactDetails(page, crn, true)
+    await navigateToNSIDetails(page, crn, true)
     await expect(page.locator('div:right-of(:text("Outcome:"))').first()).toContainText('CRS Referral Cancelled')
 })

--- a/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
+++ b/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
@@ -418,14 +418,5 @@ test('Verify Referral Cancellation by Probation Practitioner and its Reflection 
     // Verify the referral cancellation should reflect in Delius
     await loginDelius(page)
     await navigateToNSIContactDetails(page, crn, true)
-
-    //  Verify that the outcome is set to 'CRS Referral Cancelled'
-    const outcomeSiblingElement = await page.evaluate(() => {
-        const elements = document.querySelectorAll('div.form-group.form-group-sm > div.col-sm-7');
-        const matchingElement = Array.from(elements).find(element => element.textContent.includes('CRS Referral Cancelled'));
-        return matchingElement?.textContent || null;
-    });
-    expect(outcomeSiblingElement).toContain('CRS Referral Cancelled');
+    await expect(page.locator('div:right-of(:text("Outcome:"))').first()).toContainText('CRS Referral Cancelled')
 })
-
-

--- a/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
+++ b/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
@@ -1,4 +1,4 @@
-import {expect, Page, test} from '@playwright/test'
+import {expect, test} from '@playwright/test'
 import { login as loginDelius } from '../../steps/delius/login.js'
 import { logout as logoutDelius } from '../../steps/delius/logout.js'
 import { createOffender } from '../../steps/delius/offender/create-offender.js'
@@ -24,8 +24,7 @@ import { formatRMDateToDelius, Tomorrow } from '../../steps/delius/utils/date-ti
 import { createAndAssignReferral } from './common.js'
 import { createContact } from '../../steps/delius/contact/create-contact.js'
 import { deliusPerson } from '../../steps/delius/utils/person.js'
-import {cancelReferral, referralProgress} from "../../steps/referandmonitor/referral.js";
-import {findOffenderByCRN} from "../../steps/delius/offender/find-offender.js";
+import {cancelReferral} from "../../steps/referandmonitor/referral.js";
 
 test.beforeEach(async ({ page }) => {
     await loginDelius(page)

--- a/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
+++ b/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
@@ -1,4 +1,4 @@
-import {expect, test} from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { login as loginDelius } from '../../steps/delius/login.js'
 import { logout as logoutDelius } from '../../steps/delius/logout.js'
 import { createOffender } from '../../steps/delius/offender/create-offender.js'
@@ -7,12 +7,13 @@ import { createRequirementForEvent } from '../../steps/delius/requirement/create
 import {
     loginAsPractitioner,
     loginAsSupplier as loginRandMAsSupplier,
-    logout as logoutRandM
+    logout as logoutRandM,
 } from '../../steps/referandmonitor/login.js'
 import { createSupplierAssessmentAppointment } from '../../steps/referandmonitor/appointment.js'
 import { data } from '../../test-data/test-data.js'
 import {
-    navigateToNSIContactDetails, navigateToNSIDetails,
+    navigateToNSIContactDetails,
+    navigateToNSIDetails,
     rescheduleSupplierAssessmentAppointment,
     updateSAAppointmentLocation,
     verifyContact,
@@ -24,7 +25,7 @@ import { formatRMDateToDelius, Tomorrow } from '../../steps/delius/utils/date-ti
 import { createAndAssignReferral } from './common.js'
 import { createContact } from '../../steps/delius/contact/create-contact.js'
 import { deliusPerson } from '../../steps/delius/utils/person.js'
-import {cancelReferral} from "../../steps/referandmonitor/referral.js";
+import { cancelReferral } from '../../steps/referandmonitor/referral.js'
 
 test.beforeEach(async ({ page }) => {
     await loginDelius(page)
@@ -404,11 +405,7 @@ test('Verify Referral Cancellation by Probation Practitioner and its Reflection 
 
     // Generate a referral and assign it, then create a Supplier Assessment Appointment in R&M
     const referralRef = await createAndAssignReferral(page, crn)
-    await createSupplierAssessmentAppointment(
-        page,
-        referralRef,
-        addDays(new Date(), 2)
-    )
+    await createSupplierAssessmentAppointment(page, referralRef, addDays(new Date(), 2))
 
     // Find the correct referral using the Referral Reference & Cancel the Referral
     await logoutRandM(page)

--- a/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
+++ b/tests/refer-and-monitor-and-delius/reschedule-appointment.spec.ts
@@ -402,7 +402,7 @@ test('Verify Referral Cancellation by Probation Practitioner and its Reflection 
     await createCommunityEvent(page, { crn, allocation: { team: data.teams.referAndMonitorTestTeam } })
     await createRequirementForEvent(page, { crn, team: data.teams.referAndMonitorTestTeam })
 
-    // Create an initial Supplier Assessment Appointment in R&M
+    // Generate a referral and assign it, then create a Supplier Assessment Appointment in R&M
     const referralRef = await createAndAssignReferral(page, crn)
     await createSupplierAssessmentAppointment(
         page,


### PR DESCRIPTION
This commit includes the following changes:

- Add a new test case to the Playwright test suite
  - Verify referral cancellation by a Probation Practitioner and its reflection in Delius
  - Cover the creation of an offender, community event, and requirement
  - Perform referral cancellation and verify its impact on Delius
  - Enhance test coverage and improve application reliability

Additionally, modify the 'navigateToNSIContactDetails' function:

- Add an optional 'terminated' argument
- Execute non-termination code block by default if the argument is omitted or set to any other value
- Execute termination code block when 'terminated' argument is set to true
- Improve flexibility and usability of the function

Please review and provide feedback
