### PR TITLE
Fix test hang when setting event outcome

### DIFF
--- a/steps/delius/event/create-event.ts
+++ b/steps/delius/event/create-event.ts
@@ -45,18 +45,18 @@ export async function createEvent(page: Page, { crn, allocation, event, date }: 
         await selectOption(page, '#addEventForm\\:SubOffence', event.subOffence)
     }
     createdEvent.court = await selectOption(page, '#Court')
-    await selectOptionAndWait(page, '#addEventForm\\:Area', allocation?.team.provider)
-    await selectOptionAndWait(page, '#addEventForm\\:Team', allocation?.team.name)
+    await selectOptionAndWait(page, '#addEventForm\\:Area', allocation?.team?.provider)
+    await selectOptionAndWait(page, '#addEventForm\\:Team', allocation?.team?.name)
     if (allocation?.staff?.name) {
         await selectOption(page, '#addEventForm\\:Staff', allocation?.staff?.name)
     }
     await selectOption(page, '#AppearanceType', event.appearanceType)
-    await selectOption(page, '#Plea', event.plea)
+    await selectOptionAndWait(page, '#Plea', event.plea)
     await selectOptionAndWait(page, '#addEventForm\\:Outcome', event.outcome)
     createdEvent.outcome = event.outcome
     if (requiresAdditionalOutcomeDetails.includes(event.outcome)) {
-        await selectOptionAndWait(page, '#OutcomeArea', allocation?.team.provider)
-        await selectOptionAndWait(page, '#addEventForm\\:OutcomeTeam', allocation?.team.name)
+        await selectOptionAndWait(page, '#OutcomeArea', allocation?.team?.provider)
+        await selectOptionAndWait(page, '#addEventForm\\:OutcomeTeam', allocation?.team?.name)
     }
     if (event.length) {
         await page.fill('#addEventForm\\:Length', event.length)

--- a/steps/delius/utils/refresh.ts
+++ b/steps/delius/utils/refresh.ts
@@ -20,7 +20,11 @@ export const waitForJS = (page: Page, timeout = 0) => {
     return page.evaluate(timeToWait, timeout)
 }
 
-export const waitForAjax = async (page: Page) => {
-    await page.waitForResponse(page.url())
+export const waitForAjax = async (page: Page): Promise<void> => {
+    try {
+        await page.waitForResponse(page.url(), { timeout: 5000 })
+    } catch (e) {
+        console.warn('Timed out waiting for ajax, maybe there was no ajax request triggered for this field?', e)
+    }
     await waitForJS(page)
 }

--- a/test-data/environments/common.ts
+++ b/test-data/environments/common.ts
@@ -55,4 +55,5 @@ export const commonData: TestData = {
         },
     },
     teams: {},
+    prisoners: {},
 }

--- a/test-data/environments/pre-prod.ts
+++ b/test-data/environments/pre-prod.ts
@@ -27,4 +27,5 @@ export const preProdEnvironmentData: TestData = {
             location: 'Wrexham Team Office',
         },
     },
+    prisoners: {},
 }


### PR DESCRIPTION
Updates createEvent to wait for ajax after setting Plea.  Also updates waitForAjax to timeout quicker and attempt to continue.