### PR TITLE
PI-1919 Remove parallelism from data setup scripts

### DIFF
--- a/.github/workflows/setup-data.yml
+++ b/.github/workflows/setup-data.yml
@@ -41,6 +41,7 @@ jobs:
     with:
       directory: test-data-setup
       projects: '["create-case"]'
+      workers: 1
       env: |
         {
           "CREATE_DELIUS_RECORD": "${{ inputs.create_delius }}",
@@ -56,4 +57,5 @@ jobs:
     with:
       directory: test-data-setup
       projects: '["${{ inputs.project }}"]'
+      workers: 1
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ on:
         default: tests
       workers:
         description: The maximum number of concurrent worker processes that run in parallel.
-        type: number
-        default: 16
+        type: string
+        default: "16"
   # Re-use in other workflows
   workflow_call:
     inputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
         description: Directory containing test files
         type: string
         default: tests
+      workers:
+        description: The maximum number of concurrent worker processes that run in parallel.
+        type: number
+        default: 16
   # Re-use in other workflows
   workflow_call:
     inputs:
@@ -30,6 +34,10 @@ on:
         description: Extra environment variables to pass-through to the tests
         type: string
         default: ''
+      workers:
+        description: The maximum number of concurrent worker processes that run in parallel.
+        type: number
+        default: 16
 
 env:
   auto_pass_projects: '["manage-offences-and-delius","redrive-dead-letter-queues","feature-flags"]'
@@ -79,13 +87,14 @@ jobs:
 
       - name: Run Playwright tests
         id: tests
-        run: echo '${{ env.projects }}' | jq -r '.[]' | xargs npx playwright test --reporter=html,junit,json,line --workers=16
+        run: echo '${{ env.projects }}' | jq -r '.[]' | xargs npx playwright test --reporter=html,junit,json,line --workers="$WORKERS"
         env:
           TZ: Europe/London
           ENV: test
           TEST_DIR: ${{ inputs.directory }}
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit.xml
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
+          WORKERS: ${{ inputs.workers }}
           # URLs
           DELIUS_URL: https://ndelius-sr28.test.probation.service.justice.gov.uk
           WORKFORCE_URL: https://workforce-management-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
OASys accounts do not support concurrent sessions, so we must ensure they aren't in use at the same time.