### PR TITLE
Fix workers config on scheduled run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,10 @@ jobs:
         env:
           TZ: Europe/London
           ENV: test
-          TEST_DIR: ${{ inputs.directory }}
+          TEST_DIR: ${{ inputs.directory || "tests" }}
+          WORKERS: ${{ inputs.workers || "16" }}
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit.xml
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
-          WORKERS: ${{ inputs.workers }}
           # URLs
           DELIUS_URL: https://ndelius.test.probation.service.justice.gov.uk
           WORKFORCE_URL: https://workforce-management-dev.hmpps.service.justice.gov.uk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,8 @@ jobs:
         env:
           TZ: Europe/London
           ENV: test
-          TEST_DIR: ${{ inputs.directory || "tests" }}
-          WORKERS: ${{ inputs.workers || "16" }}
+          TEST_DIR: ${{ inputs.directory || 'tests' }}
+          WORKERS: ${{ inputs.workers || '16' }}
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit.xml
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
           # URLs


### PR DESCRIPTION
Fixes:
> Running 35 tests using NaN workers
https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests/actions/runs/8596645451/job/23553646926