### PR TITLE
Refactored OPD Test, Removed Skip Statements, and Addressed Failures in Unpaid Work, View Community Manager and Unpaid Work Tests

### DIFF
--- a/steps/dps/caseload.ts
+++ b/steps/dps/caseload.ts
@@ -1,7 +1,7 @@
 import { type Page } from '@playwright/test'
 
 export const switchCaseload = async (page: Page, caseload: string) => {
-    await page.locator('[data-test="change-location-link"]').click()
-    await page.getByLabel('Select active case load').selectOption(caseload)
+    await page.locator('[data-test="change-case-load-link"]').click()
+    await page.getByLabel('Select an establishment').selectOption(caseload)
     await page.getByRole('button', { name: 'Submit' }).click()
 }

--- a/steps/oasys/layer3-assessment/sign-and-lock.ts
+++ b/steps/oasys/layer3-assessment/sign-and-lock.ts
@@ -6,5 +6,6 @@ export const signAndlock = async (page: Page) => {
     await page.getByRole('button', { name: 'Sign & Lock' }).click()
     await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
     await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
+    await page.locator('#searchtop > h2').isVisible({timeout: 15000})
     await expect(page.locator('#searchtop > h2')).toHaveText('Task Manager')
 }

--- a/steps/oasys/layer3-assessment/sign-and-lock.ts
+++ b/steps/oasys/layer3-assessment/sign-and-lock.ts
@@ -6,6 +6,6 @@ export const signAndlock = async (page: Page) => {
     await page.getByRole('button', { name: 'Sign & Lock' }).click()
     await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
     await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
-    await page.locator('#searchtop > h2').isVisible({timeout: 15000})
+    await page.locator('#searchtop > h2').isVisible({ timeout: 15000 })
     await expect(page.locator('#searchtop > h2')).toHaveText('Task Manager')
 }

--- a/tests/opd-and-delius/opd-assessment.spec.ts
+++ b/tests/opd-and-delius/opd-assessment.spec.ts
@@ -13,6 +13,7 @@ import { navigateToNSIDetailsFromPersonalDetails } from '../../steps/delius/cont
 dotenv.config() // read environment variables into process.env
 
 test('OPD assessment creates an event in Delius', async ({ page }) => {
+    test.slow()
     await loginDelius(page)
     const dob = faker.date.birthdate({ min: 20, max: 30, mode: 'age' })
     const person = deliusPerson({ sex: 'Male', dob: dob })

--- a/tests/prison-education-and-delius/view-community-manager.spec.ts
+++ b/tests/prison-education-and-delius/view-community-manager.spec.ts
@@ -33,7 +33,7 @@ test('View Community manager details', async ({ page }) => {
     await dpsLogin(page)
     await switchCaseload(page, 'SWI')
     await page.getByRole('link', { name: 'Get someone ready to work' }).first().click()
-    await page.locator('[class="govuk-link card__link"]', { hasText: 'Get someone ready to work'}).click()
+    await page.locator('[class="govuk-link card__link"]', { hasText: 'Get someone ready to work' }).click()
     await page.getByLabel(`Profile link for ${person.lastName}, ${person.firstName}`).click()
     await page.getByRole('link', { name: 'Contacts' }).click()
     await expect(page.locator('main')).toContainText(data.staff.genericStaff.firstName)

--- a/tests/prison-education-and-delius/view-community-manager.spec.ts
+++ b/tests/prison-education-and-delius/view-community-manager.spec.ts
@@ -34,7 +34,6 @@ test('View Community manager details', async ({ page }) => {
     await switchCaseload(page, 'SWI')
     await page.getByRole('link', { name: 'Get someone ready to work' }).first().click()
     await page.locator('[class="govuk-link card__link"]', { hasText: 'Get someone ready to work'}).click()
-
     await page.getByLabel(`Profile link for ${person.lastName}, ${person.firstName}`).click()
     await page.getByRole('link', { name: 'Contacts' }).click()
     await expect(page.locator('main')).toContainText(data.staff.genericStaff.firstName)

--- a/tests/prison-education-and-delius/view-community-manager.spec.ts
+++ b/tests/prison-education-and-delius/view-community-manager.spec.ts
@@ -17,8 +17,6 @@ const nomisIds = []
 const bookingIds = []
 
 test('View Community manager details', async ({ page }) => {
-    // skipped temporarily until application is using the integration
-    test.skip()
     // Given a prisoner with a release date within the next 12 weeks
     await deliusLogin(page)
     const person = deliusPerson()
@@ -34,7 +32,9 @@ test('View Community manager details', async ({ page }) => {
     // Then the Community Manager details appear in the Get Someone Ready To Work service
     await dpsLogin(page)
     await switchCaseload(page, 'SWI')
-    await page.getByRole('link', { name: 'Get someone ready to work' }).click()
+    await page.getByRole('link', { name: 'Get someone ready to work' }).first().click()
+    await page.locator('[class="govuk-link card__link"]', { hasText: 'Get someone ready to work'}).click()
+
     await page.getByLabel(`Profile link for ${person.lastName}, ${person.firstName}`).click()
     await page.getByRole('link', { name: 'Contacts' }).click()
     await expect(page.locator('main')).toContainText(data.staff.genericStaff.firstName)

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -55,9 +55,7 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
         () => expect(page.locator('table')).toContainText('CP/UPW Assessment')
     )
 
-    await expect(page.locator('#documentDrawerTable > tbody > tr')).toContainText(
-        format(new Date(), 'dd/MM/yyyy')
-    )
+    await expect(page.locator('#documentDrawerTable > tbody > tr')).toContainText(format(new Date(), 'dd/MM/yyyy'))
     await expect(page.getByRole('link', { name: 'view document' })).toBeEnabled()
 
     // And I verify the content in the PDF (CRN)

--- a/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
+++ b/tests/unpaid-work-and-delius/create-upw-assessment.spec.ts
@@ -19,8 +19,7 @@ import { getPdfText } from '../../steps/delius/utils/pdf-utils'
 
 const nomisIds = []
 test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to Delius', async ({ page }) => {
-    // skipped temporarily until Delius completes the development
-    test.skip()
+    test.slow()
     // Given I create new Offender in nDelius
     await deliusLogin(page)
     const person = deliusPerson()
@@ -56,7 +55,7 @@ test('Create a UPW-Assessment from Delius and verify the Pdf is uploaded back to
         () => expect(page.locator('table')).toContainText('CP/UPW Assessment')
     )
 
-    await expect(page.locator('#documentListForm\\:documentDrawerTable\\:tbody_element')).toContainText(
+    await expect(page.locator('#documentDrawerTable > tbody > tr')).toContainText(
         format(new Date(), 'dd/MM/yyyy')
     )
     await expect(page.getByRole('link', { name: 'view document' })).toBeEnabled()


### PR DESCRIPTION
**Pull Request Summary:**

This PR encompasses the following enhancements and fixes to the End2End test suite:

1. Resolved the issue with the 'OPD assessment creates an event in Delius' test.
2. Addressed the failure in the Unpaid Work test by removing the Skip statement.
3. Fixed the failure in the 'View Community manager details' test by removing the Skip statement.
4. Integrated the latest DPS application changes to fix the failure in the 'View case in Create and Vary a Licence' test and removed the Skip statement.

**Note:** One test, 'View case in Create and Vary a Licence', remains skipped. It currently serves as a placeholder for future integration work and connectivity testing, as indicated by the provided comment.