### PR TITLE
PI-2118 - Resolved Failures in Tests for Approved Premises and View Community Manager

### DIFF
--- a/steps/cas1-approved-premises/applications/assess-application.ts
+++ b/steps/cas1-approved-premises/applications/assess-application.ts
@@ -78,5 +78,5 @@ export const assessApplication = async (page: Page, personName: string) => {
     await page.getByRole('link', { name: 'Check assessment answers' }).click()
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByLabel('I confirm the information provided is complete, accurate and up to date.').check()
-    await page.getByRole('button', { name: 'Submit application' }).click()
+    await page.getByRole('button', { name: 'Submit assessment' }).click()
 }

--- a/tests/hdc-licences-and-delius/view-community-manager.spec.ts
+++ b/tests/hdc-licences-and-delius/view-community-manager.spec.ts
@@ -9,7 +9,7 @@ import { data } from '../../test-data/test-data'
 const nomisIds = []
 
 test('View community manager in HDC', async ({ page }) => {
-    // Given a case in Delius and NOMI
+    // Given a case in Delius and NOMIS
     await deliusLogin(page)
     const person = deliusPerson()
     const crn: string = await createOffender(page, { person, providerName: data.teams.genericTeam.provider })

--- a/tests/hdc-licences-and-delius/view-community-manager.spec.ts
+++ b/tests/hdc-licences-and-delius/view-community-manager.spec.ts
@@ -22,14 +22,16 @@ test('View community manager in HDC', async ({ page }) => {
     await page.getByLabel(/Enter prisoner name or ID/).fill(nomisId)
     await page.getByRole('button', { name: 'Search' }).click()
     const [newPage] = await Promise.all([
-         page.waitForEvent('popup'),
-         page.getByRole('link', { name: 'Update HDC licence' }).click()
+        page.waitForEvent('popup'),
+        page.getByRole('link', { name: 'Update HDC licence' }).click(),
     ])
     await newPage.waitForLoadState()
 
     // Then I can see the probation data
     await newPage.locator('#prisonerComName a').click()
-    await expect(newPage.locator(":text('Probation area') ~ div").first()).toContainText(data.teams.genericTeam.provider)
+    await expect(newPage.locator(":text('Probation area') ~ div").first()).toContainText(
+        data.teams.genericTeam.provider
+    )
 })
 
 test.afterAll(async () => {

--- a/tests/hdc-licences-and-delius/view-community-manager.spec.ts
+++ b/tests/hdc-licences-and-delius/view-community-manager.spec.ts
@@ -9,7 +9,7 @@ import { data } from '../../test-data/test-data'
 const nomisIds = []
 
 test('View community manager in HDC', async ({ page }) => {
-    // Given a case in Delius and NOMIS
+    // Given a case in Delius and NOMI
     await deliusLogin(page)
     const person = deliusPerson()
     const crn: string = await createOffender(page, { person, providerName: data.teams.genericTeam.provider })
@@ -21,12 +21,15 @@ test('View community manager in HDC', async ({ page }) => {
     await page.getByRole('link', { name: 'Search all offenders' }).click()
     await page.getByLabel(/Enter prisoner name or ID/).fill(nomisId)
     await page.getByRole('button', { name: 'Search' }).click()
-    await page.getByRole('link', { name: 'Update HDC licence' }).click()
-    const popup = await page.waitForEvent('popup')
+    const [newPage] = await Promise.all([
+         page.waitForEvent('popup'),
+         page.getByRole('link', { name: 'Update HDC licence' }).click()
+    ])
+    await newPage.waitForLoadState()
 
     // Then I can see the probation data
-    await popup.locator('#prisonerComName a').click()
-    await expect(popup.locator(":text('Probation area') ~ div").first()).toContainText(data.teams.genericTeam.provider)
+    await newPage.locator('#prisonerComName a').click()
+    await expect(newPage.locator(":text('Probation area') ~ div").first()).toContainText(data.teams.genericTeam.provider)
 })
 
 test.afterAll(async () => {


### PR DESCRIPTION
**PR Summary:**

The Pull Request covers the following changes:

1. Addressed issues with Approved Premises tests by integrating updates from the AP application.
2. Refactored the 'view community manager in HDC' test to accommodate changes in HDC application behavior. Previously, HDC opened in a new browser, but now it opens in a new tab within the same browser. The test was failing due to this change, and it was fixed by adapting the code to handle the new tab instead of a new browser instance.