### PR TITLE
PI-2172 - Implement End-to-End Test for "View Case" in Create and Vary a Licence (CVL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
           MANAGE_POM_CASES_URL: https://dev.moic.service.justice.gov.uk
           RESETTLEMENT_PASSPORT_AND_DELIUS_API: https://resettlement-passport-and-delius-dev.hmpps.service.justice.gov.uk
           CVL_URL: https://create-and-vary-a-licence-test2.hmpps.service.justice.gov.uk
+          CVL_API: https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk
           CAS2_SHORT_TERM_ACCOMMODATION_URL: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk
           CAS3_TRANSITIONAL_ACCOMMODATION_URL: https://transitional-accommodation-dev.hmpps.service.justice.gov.uk
           TIER_UI_URL: https://tier-dev.hmpps.service.justice.gov.uk

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ CONSIDER_A_RECALL_MRD_PASSWORD=<mrd_password>
 MANAGE_POM_CASES_URL=https://dev.moic.service.justice.gov.uk
 
 CVL_URL=https://create-and-vary-a-licence-test2.hmpps.service.justice.gov.uk
+CVL_API=https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk
 
 TIER_UI_URL=https://tier-dev.hmpps.service.justice.gov.uk
 

--- a/steps/api/cvl/cvl-api.ts
+++ b/steps/api/cvl/cvl-api.ts
@@ -1,4 +1,4 @@
-import { type APIRequestContext, Page, request } from '@playwright/test'
+import { type APIRequestContext, request } from '@playwright/test'
 import { getToken } from '../auth/get-token'
 import { retry, sanitiseError } from '../utils/api-utils'
 

--- a/steps/api/cvl/cvl-api.ts
+++ b/steps/api/cvl/cvl-api.ts
@@ -34,7 +34,7 @@ export const discardAllLicences = async function (crn: string){
 
 export const discardLicence = retry(
     sanitiseError(async (licenceId: string) => {
-        const response = await (
+        await (
             await getContext()
         ).post(`/licence/id/${licenceId}/override/status`, {
             failOnStatusCode: true,

--- a/steps/api/cvl/cvl-api.ts
+++ b/steps/api/cvl/cvl-api.ts
@@ -21,14 +21,14 @@ export const getLicenceIds = retry(
             failOnStatusCode: true,
         })
         const json = await response.json()
-        return json.filter(l => l.statusCode !== "INACTIVE").map(l => l.id)
+        return json.filter(l => l.statusCode !== 'INACTIVE').map(l => l.id)
     })
 )
 
-export const discardAllLicences = async function (crn: string){
-   const licenceIds = await getLicenceIds(crn)
+export const discardAllLicences = async function (crn: string) {
+    const licenceIds = await getLicenceIds(crn)
     for (const id of licenceIds) {
-        await discardLicence(id);
+        await discardLicence(id)
     }
 }
 

--- a/steps/api/cvl/cvl-api.ts
+++ b/steps/api/cvl/cvl-api.ts
@@ -1,0 +1,47 @@
+import { type APIRequestContext, Page, request } from '@playwright/test'
+import { getToken } from '../auth/get-token'
+import { retry, sanitiseError } from '../utils/api-utils'
+
+async function getContext(): Promise<APIRequestContext> {
+    const token = await getToken()
+    return request.newContext({
+        baseURL: process.env.CVL_API,
+        extraHTTPHeaders: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+    })
+}
+
+export const getLicenceIds = retry(
+    sanitiseError(async (crn: string) => {
+        const response = await (
+            await getContext()
+        ).get(`/public/licence-summaries/crn/${crn}`, {
+            failOnStatusCode: true,
+        })
+        const json = await response.json()
+        return json.filter(l => l.statusCode !== "INACTIVE").map(l => l.id)
+    })
+)
+
+export const discardAllLicences = async function (crn: string){
+   const licenceIds = await getLicenceIds(crn)
+    for (const id of licenceIds) {
+        await discardLicence(id);
+    }
+}
+
+export const discardLicence = retry(
+    sanitiseError(async (licenceId: string) => {
+        const response = await (
+            await getContext()
+        ).post(`/licence/id/${licenceId}/override/status`, {
+            failOnStatusCode: true,
+            data: {
+                statusCode: 'INACTIVE',
+                reason: 'Testing',
+            },
+        })
+    })
+)

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -1,0 +1,49 @@
+import { expect, Page } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {login as cvlLogin, loginAsPrisonOfficer} from "./login.js";
+
+export const createLicence = async (page: any, crn: string, nomsNumber: string) => {
+    await cvlLogin(page)
+    await page.getByRole('link', { name: 'Create and edit a licence before a release date' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Caseload')
+    await page.getByLabel('Find a case').fill(crn)
+    await page.getByRole('button', { name: 'Search' }).click()
+    await page.locator(`[href*="${nomsNumber}"]`).click();
+    await expect(page).toHaveTitle(/Create and vary a licence - Create a licence - Are you sure?/)
+    await page.getByRole('button', { name: /Continue and create licence/}).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Who is the initial appointment with?')
+    await page.getByLabel(/Who is the initial appointment with?/).fill(faker.person.fullName())
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Where is the initial appointment?')
+    await page.getByLabel(/Building and street/).first().fill(faker.location.buildingNumber() + " " + faker.location.street())
+    await page.getByLabel(/Town or city/).fill(faker.location.city())
+    await page.getByLabel('County (optional)').fill(faker.location.county());
+    await page.getByLabel(/Postcode/).fill(faker.location.zipCode())
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - What is the contact phone number for the initial appointment?')
+    await page.getByLabel('UK telephone number').fill('01632 960901');
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - When is the initial appointment?')
+    await page.getByLabel(/Immediately after release/).check()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Additional Post Sentence Supervision Conditions')
+    await page.getByLabel(/No/).check()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Check your answers')
+    await page.getByRole('button', { name: /Send to prison for approval/ }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Confirmation')
+    await page.getByRole('link', { name: /Sign out/ }).click()
+};
+
+export const approveLicence = async (page: any, crn: string, nomsNumber: string) => {
+    await loginAsPrisonOfficer(page)
+    await page.getByRole('link', { name: 'Approve a licence' }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - approval cases')
+    await page.getByLabel('Find a case').fill(crn)
+    await page.locator(`tr:has([data-sort-value="${nomsNumber}"]) td#name-1 a.govuk-link`).click();
+    await expect(page).toHaveTitle('Create and vary a licence - Approve a licence')
+    await page.getByRole('button', { name: /Approve/ }).click()
+    await expect(page).toHaveTitle('Create and vary a licence - licence approved')
+    await page.locator('[data-qa$="user-name"]').click()
+    await page.getByRole('link', { name: /Sign out/ }).click()
+};

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -1,6 +1,6 @@
-import {expect, Page} from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { faker } from '@faker-js/faker'
-import {login as cvlLogin, loginAsPrisonOfficer} from "./login.js";
+import { login as cvlLogin, loginAsPrisonOfficer } from './login.js'
 
 export const createLicence = async (page: Page, crn: string, nomsNumber: string) => {
     await cvlLogin(page)
@@ -8,50 +8,63 @@ export const createLicence = async (page: Page, crn: string, nomsNumber: string)
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Caseload')
     await page.getByLabel('Find a case').fill(crn)
     await page.getByRole('button', { name: 'Search' }).click()
-    await page.locator(`[href*="${nomsNumber}"]`).click();
+    await page.locator(`[href*="${nomsNumber}"]`).click()
     await expect(page).toHaveTitle(/Create and vary a licence - Create a licence - Are you sure?/)
-    await page.getByRole('button', { name: /Continue and create licence/}).click()
-    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Who is the initial appointment with?')
+    await page.getByRole('button', { name: /Continue and create licence/ }).click()
+    await expect(page).toHaveTitle(
+        'Create and vary a licence - Create a licence - Who is the initial appointment with?'
+    )
     await page.getByLabel(/Who is the initial appointment with?/).fill(faker.person.fullName())
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Where is the initial appointment?')
-    await page.getByLabel(/Building and street/).first().fill(faker.location.buildingNumber() + " " + faker.location.street())
+    await page
+        .getByLabel(/Building and street/)
+        .first()
+        .fill(faker.location.buildingNumber() + ' ' + faker.location.street())
     await page.getByLabel(/Town or city/).fill(faker.location.city())
-    await page.getByLabel('County (optional)').fill(faker.location.county());
+    await page.getByLabel('County (optional)').fill(faker.location.county())
     await page.getByLabel(/Postcode/).fill(faker.location.zipCode())
     await page.getByRole('button', { name: 'Continue' }).click()
-    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - What is the contact phone number for the initial appointment?')
-    await page.getByLabel('UK telephone number').fill(cvlFormattedPhoneNumber());
+    await expect(page).toHaveTitle(
+        'Create and vary a licence - Create a licence - What is the contact phone number for the initial appointment?'
+    )
+    await page.getByLabel('UK telephone number').fill(cvlFormattedPhoneNumber())
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - When is the initial appointment?')
     await page.getByLabel(/Immediately after release/).check()
     await page.getByRole('button', { name: 'Continue' }).click()
-    await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Additional Post Sentence Supervision Conditions')
+    await expect(page).toHaveTitle(
+        'Create and vary a licence - Create a licence - Additional Post Sentence Supervision Conditions'
+    )
     await page.getByLabel(/No/).check()
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Check your answers')
     await page.getByRole('button', { name: /Send to prison for approval/ }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Confirmation')
     await page.getByRole('link', { name: /Sign out/ }).click()
-};
+}
 
 export const approveLicence = async (page: Page, crn: string, nomsNumber: string) => {
     await loginAsPrisonOfficer(page)
     await page.getByRole('link', { name: 'Approve a licence' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - approval cases')
     await page.getByLabel('Find a case').fill(crn)
-    await page.locator(`tr:has([data-sort-value="${nomsNumber}"]) td#name-1 a.govuk-link`).click();
+    await page.locator(`tr:has([data-sort-value="${nomsNumber}"]) td#name-1 a.govuk-link`).click()
     await expect(page).toHaveTitle('Create and vary a licence - Approve a licence')
     await page.getByRole('button', { name: /Approve/ }).click()
     await expect(page).toHaveTitle('Create and vary a licence - licence approved')
     await page.locator('[data-qa$="user-name"]').click()
     await page.getByRole('link', { name: /Sign out/ }).click()
-};
+}
 
 const cvlFormattedPhoneNumber = (): string => {
-    const areaCode = '01' + Math.floor(Math.random() * 1000).toString().padStart(2, '0'); // Generate a random 3-digit number as the last 3 digits of the area code
-    const cityNumber = Math.floor(Math.random() * 1000000).toString().padStart(6, '0'); // Generate a random 6-digit city number
-    return `${areaCode} ${cityNumber}`;
-};
-
-
+    const areaCode =
+        '01' +
+        Math.floor(Math.random() * 1000)
+            .toString()
+            .padStart(2, '0') // Generate a random 3-digit number as the last 3 digits of the area code
+    const cityNumber = Math.floor(Math.random() * 1000000)
+        .toString()
+        .padStart(6, '0') // Generate a random 6-digit city number
+    return `${areaCode} ${cityNumber}`
+}

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -21,7 +21,7 @@ export const createLicence = async (page: Page, crn: string, nomsNumber: string)
     await page.getByLabel(/Postcode/).fill(faker.location.zipCode())
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - What is the contact phone number for the initial appointment?')
-    await page.getByLabel('UK telephone number').fill('01632 960901');
+    await page.getByLabel('UK telephone number').fill(cvlFormattedPhoneNumber());
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - When is the initial appointment?')
     await page.getByLabel(/Immediately after release/).check()
@@ -47,3 +47,11 @@ export const approveLicence = async (page: Page, crn: string, nomsNumber: string
     await page.locator('[data-qa$="user-name"]').click()
     await page.getByRole('link', { name: /Sign out/ }).click()
 };
+
+const cvlFormattedPhoneNumber = (): string => {
+    const areaCode = '01' + Math.floor(Math.random() * 1000).toString().padStart(2, '0'); // Generate a random 3-digit number as the last 3 digits of the area code
+    const cityNumber = Math.floor(Math.random() * 1000000).toString().padStart(6, '0'); // Generate a random 6-digit city number
+    return `${areaCode} ${cityNumber}`;
+};
+
+

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -1,8 +1,8 @@
-import { expect, Page } from '@playwright/test'
+import {expect, Page} from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import {login as cvlLogin, loginAsPrisonOfficer} from "./login.js";
 
-export const createLicence = async (page: any, crn: string, nomsNumber: string) => {
+export const createLicence = async (page: Page, crn: string, nomsNumber: string) => {
     await cvlLogin(page)
     await page.getByRole('link', { name: 'Create and edit a licence before a release date' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - Caseload')
@@ -35,7 +35,7 @@ export const createLicence = async (page: any, crn: string, nomsNumber: string) 
     await page.getByRole('link', { name: /Sign out/ }).click()
 };
 
-export const approveLicence = async (page: any, crn: string, nomsNumber: string) => {
+export const approveLicence = async (page: Page, crn: string, nomsNumber: string) => {
     await loginAsPrisonOfficer(page)
     await page.getByRole('link', { name: 'Approve a licence' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - approval cases')

--- a/steps/cvl-licences/login.ts
+++ b/steps/cvl-licences/login.ts
@@ -8,3 +8,12 @@ export const login = async (page: Page) => {
     await page.click('#submit')
     await expect(page).toHaveTitle(/Create and vary a licence - Home/)
 }
+
+export const loginAsPrisonOfficer = async (page: Page) => {
+    await page.goto(process.env.CVL_URL)
+    await expect(page).toHaveTitle(/HMPPS Digital Services - Sign in/)
+    await page.fill('#username', process.env.DPS_USERNAME!)
+    await page.fill('#password', process.env.DPS_PASSWORD!)
+    await page.click('#submit')
+    await expect(page).toHaveTitle(/Create and vary a licence - Home/)
+}

--- a/steps/delius/licence-condition/create-licence-condition.ts
+++ b/steps/delius/licence-condition/create-licence-condition.ts
@@ -18,8 +18,8 @@ export const createLicenceCondition = async (page: Page, crn: string, eventNumbe
 }
 
 export const navigateToLicenceConditions = async (page: Page, crn: string, eventNumber = 1): Promise<void> => {
-    await findEventByCRN(page, crn, eventNumber);
-    await page.getByRole('link', {name: 'Licence conditions'}).click()
+    await findEventByCRN(page, crn, eventNumber)
+    await page.getByRole('link', { name: 'Licence conditions' }).click()
 }
 
-export const deliusLicenceCondition = 'table tr:first-child td:nth-child(2)';
+export const deliusLicenceCondition = 'table tr:first-child td:nth-child(2)'

--- a/steps/delius/licence-condition/create-licence-condition.ts
+++ b/steps/delius/licence-condition/create-licence-condition.ts
@@ -16,3 +16,10 @@ export const createLicenceCondition = async (page: Page, crn: string, eventNumbe
     await expect(page.locator('h1')).toHaveText('Licence Conditions')
     return await page.locator('table tr:first-child td:nth-child(2)').textContent()
 }
+
+export const navigateToLicenceConditions = async (page: Page, crn: string, eventNumber = 1): Promise<void> => {
+    await findEventByCRN(page, crn, eventNumber);
+    await page.getByRole('link', {name: 'Licence conditions'}).click()
+}
+
+export const deliusLicenceCondition = 'table tr:first-child td:nth-child(2)';

--- a/steps/delius/licence-condition/delete-licence-condition.ts
+++ b/steps/delius/licence-condition/delete-licence-condition.ts
@@ -2,20 +2,18 @@ import { expect, type Page } from '@playwright/test'
 import { findEventByCRN } from '../event/find-events'
 
 export const deleteLicenceConditions = async (page: Page, crn: string, eventNumber = 1): Promise<void> => {
-    await findEventByCRN(page, crn, eventNumber);
-    await page.getByRole('link', { name: 'Licence Conditions' }).click();
-    await expect(page.locator('h1')).toHaveText('Licence Conditions');
+    await findEventByCRN(page, crn, eventNumber)
+    await page.getByRole('link', { name: 'Licence Conditions' }).click()
+    await expect(page.locator('h1')).toHaveText('Licence Conditions')
 
     // Get all "delete" links
-    const deleteLinks = await page.locator('#licenceConditionTable [title="Delete licence condition"]').all();
+    const deleteLinks = await page.locator('#licenceConditionTable [title="Delete licence condition"]').all()
 
     // Iterate over each delete link and click on it
     for (const deleteLink of deleteLinks) {
-        await deleteLink.click();
+        await deleteLink.click()
         await expect(page.locator('#content > h1')).toHaveText('Delete Licence Condition')
-        await page.getByRole('button', { name: 'Confirm' }).click();
-        await expect(page.locator('h1')).toHaveText('Licence Conditions');
+        await page.getByRole('button', { name: 'Confirm' }).click()
+        await expect(page.locator('h1')).toHaveText('Licence Conditions')
     }
-};
-
-
+}

--- a/steps/delius/licence-condition/delete-licence-condition.ts
+++ b/steps/delius/licence-condition/delete-licence-condition.ts
@@ -12,8 +12,6 @@ export const deleteLicenceConditions = async (page: Page, crn: string, eventNumb
     // Iterate over each delete link and click on it
     for (const deleteLink of deleteLinks) {
         await deleteLink.click();
-        // Add a short delay to allow the page to process the deletion
-        await page.waitForTimeout(1000);
         await expect(page.locator('#content > h1')).toHaveText('Delete Licence Condition')
         await page.getByRole('button', { name: 'Confirm' }).click();
         await expect(page.locator('h1')).toHaveText('Licence Conditions');

--- a/steps/delius/licence-condition/delete-licence-condition.ts
+++ b/steps/delius/licence-condition/delete-licence-condition.ts
@@ -1,0 +1,23 @@
+import { expect, type Page } from '@playwright/test'
+import { findEventByCRN } from '../event/find-events'
+
+export const deleteLicenceConditions = async (page: Page, crn: string, eventNumber = 1): Promise<void> => {
+    await findEventByCRN(page, crn, eventNumber);
+    await page.getByRole('link', { name: 'Licence Conditions' }).click();
+    await expect(page.locator('h1')).toHaveText('Licence Conditions');
+
+    // Get all "delete" links
+    const deleteLinks = await page.locator('#licenceConditionTable [title="Delete licence condition"]').all();
+
+    // Iterate over each delete link and click on it
+    for (const deleteLink of deleteLinks) {
+        await deleteLink.click();
+        // Add a short delay to allow the page to process the deletion
+        await page.waitForTimeout(1000);
+        await expect(page.locator('#content > h1')).toHaveText('Delete Licence Condition')
+        await page.getByRole('button', { name: 'Confirm' }).click();
+        await expect(page.locator('h1')).toHaveText('Licence Conditions');
+    }
+};
+
+

--- a/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
+++ b/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
@@ -1,4 +1,4 @@
-import {expect, type Page, test} from '@playwright/test'
+import {expect, test} from '@playwright/test'
 import * as dotenv from 'dotenv'
 import {data} from '../../test-data/test-data'
 import {login as deliusLogin} from "../../steps/delius/login.js";
@@ -19,7 +19,7 @@ test('View case in Create and Vary a Licence', async ({page}) => {
 
     // Check if the CRN is in the right state (no active licence to release, and the offender is still in prison).
     // Recall the prisoner to put the CRN in the right state and discard all existing licences.
-    await resetLicenceCase(page);
+    await resetLicenceCase();
 
     // Delete the existing licence conditions in Delius.
     await deliusLogin(page);

--- a/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
+++ b/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
@@ -40,7 +40,7 @@ test('View case in Create and Vary a Licence', async ({page}) => {
         {timeout: 120_000});
 });
 
-const resetLicenceCase = async (page: Page) => {
+const resetLicenceCase = async () => {
     //Recall the prisoner and discard all the existing licences
     try {
         await recallPrisoner(data.prisoners.sentencedPrisonerWithReleaseDate.nomsNumber)

--- a/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
+++ b/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
@@ -1,16 +1,51 @@
-import { expect, test } from '@playwright/test'
+import {expect, type Page, test} from '@playwright/test'
 import * as dotenv from 'dotenv'
-import { login as cvlLogin } from '../../steps/cvl-licences/login'
-import { data } from '../../test-data/test-data'
+import {data} from '../../test-data/test-data'
+import {login as deliusLogin} from "../../steps/delius/login.js";
+import {recallPrisoner, releasePrisoner} from "../../steps/api/dps/prison-api.js";
+import {discardAllLicences} from "../../steps/api/cvl/cvl-api.js";
+import {deleteLicenceConditions} from "../../steps/delius/licence-condition/delete-licence-condition.js";
+import {refreshUntil} from "../../steps/delius/utils/refresh.js";
+import {approveLicence, createLicence} from "../../steps/cvl-licences/application.js";
+import {
+    deliusLicenceCondition,
+    navigateToLicenceConditions
+} from "../../steps/delius/licence-condition/create-licence-condition.js";
 
 dotenv.config() // read environment variables into process.env
 
-test('View case in Create and Vary a Licence', async ({ page }) => {
-    test.skip() // This test doesn't do anything yet, it just proves connectivity. We should write a proper test when we do the CVL integration.
+test('View case in Create and Vary a Licence', async ({page}) => {
+    const {crn, nomsNumber} = data.prisoners.sentencedPrisonerWithReleaseDate;
 
-    await cvlLogin(page)
-    await page.getByRole('link', { name: 'Create and edit a licence before a release date' }).click()
-    await expect(page.locator('.caseload-offender-name')).toContainText(
-        data.prisoners.sentencedPrisonerWithReleaseDate.crn
-    )
-})
+    // Check if the CRN is in the right state (no active licence to release, and the offender is still in prison).
+    // Recall the prisoner to put the CRN in the right state and discard all existing licences.
+    await resetLicenceCase(page);
+
+    // Delete the existing licence conditions in Delius.
+    await deliusLogin(page);
+    await deleteLicenceConditions(page, crn);
+
+    // Create a licence in CVL and approve it.
+    await createLicence(page, crn, nomsNumber);
+    await approveLicence(page, crn, nomsNumber);
+
+    // Release the prisoner to apply the licence conditions.
+    await releasePrisoner(nomsNumber);
+
+    // Verify that the licence condition appears in Delius.
+    await deliusLogin(page);
+    await navigateToLicenceConditions(page, crn);
+    await refreshUntil(page, () =>
+            expect(page.locator(deliusLicenceCondition)).toHaveText('Standard 9 Conditions - Standard 9 Conditions'),
+        {timeout: 120_000});
+});
+
+const resetLicenceCase = async (page: Page) => {
+    //Recall the prisoner and discard all the existing licences
+    try {
+        await recallPrisoner(data.prisoners.sentencedPrisonerWithReleaseDate.nomsNumber)
+    } catch (e) {
+        console.log("Recall Failed, Likely to be already in the prison")
+    }
+    await discardAllLicences(data.prisoners.sentencedPrisonerWithReleaseDate.crn)
+}

--- a/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
+++ b/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
@@ -1,51 +1,53 @@
-import {expect, test} from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import * as dotenv from 'dotenv'
-import {data} from '../../test-data/test-data'
-import {login as deliusLogin} from "../../steps/delius/login.js";
-import {recallPrisoner, releasePrisoner} from "../../steps/api/dps/prison-api.js";
-import {discardAllLicences} from "../../steps/api/cvl/cvl-api.js";
-import {deleteLicenceConditions} from "../../steps/delius/licence-condition/delete-licence-condition.js";
-import {refreshUntil} from "../../steps/delius/utils/refresh.js";
-import {approveLicence, createLicence} from "../../steps/cvl-licences/application.js";
+import { data } from '../../test-data/test-data'
+import { login as deliusLogin } from '../../steps/delius/login.js'
+import { recallPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api.js'
+import { discardAllLicences } from '../../steps/api/cvl/cvl-api.js'
+import { deleteLicenceConditions } from '../../steps/delius/licence-condition/delete-licence-condition.js'
+import { refreshUntil } from '../../steps/delius/utils/refresh.js'
+import { approveLicence, createLicence } from '../../steps/cvl-licences/application.js'
 import {
     deliusLicenceCondition,
-    navigateToLicenceConditions
-} from "../../steps/delius/licence-condition/create-licence-condition.js";
+    navigateToLicenceConditions,
+} from '../../steps/delius/licence-condition/create-licence-condition.js'
 
 dotenv.config() // read environment variables into process.env
 
-test('View case in Create and Vary a Licence', async ({page}) => {
-    const {crn, nomsNumber} = data.prisoners.sentencedPrisonerWithReleaseDate;
+test('View case in Create and Vary a Licence', async ({ page }) => {
+    const { crn, nomsNumber } = data.prisoners.sentencedPrisonerWithReleaseDate
 
     // Check if the CRN is in the right state (no active licence to release, and the offender is still in prison).
     // Recall the prisoner to put the CRN in the right state and discard all existing licences.
-    await resetLicenceCase();
+    await resetLicenceCase()
 
     // Delete the existing licence conditions in Delius.
-    await deliusLogin(page);
-    await deleteLicenceConditions(page, crn);
+    await deliusLogin(page)
+    await deleteLicenceConditions(page, crn)
 
     // Create a licence in CVL and approve it.
-    await createLicence(page, crn, nomsNumber);
-    await approveLicence(page, crn, nomsNumber);
+    await createLicence(page, crn, nomsNumber)
+    await approveLicence(page, crn, nomsNumber)
 
     // Release the prisoner to apply the licence conditions.
-    await releasePrisoner(nomsNumber);
+    await releasePrisoner(nomsNumber)
 
     // Verify that the licence condition appears in Delius.
-    await deliusLogin(page);
-    await navigateToLicenceConditions(page, crn);
-    await refreshUntil(page, () =>
-            expect(page.locator(deliusLicenceCondition)).toHaveText('Standard 9 Conditions - Standard 9 Conditions'),
-        {timeout: 120_000});
-});
+    await deliusLogin(page)
+    await navigateToLicenceConditions(page, crn)
+    await refreshUntil(
+        page,
+        () => expect(page.locator(deliusLicenceCondition)).toHaveText('Standard 9 Conditions - Standard 9 Conditions'),
+        { timeout: 120_000 }
+    )
+})
 
 const resetLicenceCase = async () => {
     //Recall the prisoner and discard all the existing licences
     try {
         await recallPrisoner(data.prisoners.sentencedPrisonerWithReleaseDate.nomsNumber)
     } catch (e) {
-        console.log("Recall Failed, Likely to be already in the prison")
+        console.log('Recall Failed, Likely to be already in the prison')
     }
     await discardAllLicences(data.prisoners.sentencedPrisonerWithReleaseDate.crn)
 }


### PR DESCRIPTION
This pull request adds an end-to-end test for the "View Case" functionality in Create and Vary a Licence (CVL). The test scenario covers the following steps:

1. Given a Case Reference Number (CRN) with the creation and booking of the NOMIS case & sentence.
2. Check if the CRN is in the right state (no active licence to release, and the offender is still in prison) using an API Call.
3. Recall the prisoner to put the CRN in the right state using an API Call.
4. Discard all existing licences using an API Call.
5. Login to Delius and delete the existing licence conditions.
6. Login to CVL as a Probation Officer and create a Licence for the CRN.
7. Login to CVL as a Prison Officer and approve the Licence for the CRN.
8. Release the prisoner to apply the licence conditions using an API Call.
9. Login to Delius and navigate to Licence Condition.
10. Verify that the licence condition appears in Delius.
