### PR TITLE
PI-2233: Fix Test Data Setup Failure for OASys Assessment Creation in E2E Tests

### DIFF
--- a/steps/oasys/layer3-assessment/create-assessment.ts
+++ b/steps/oasys/layer3-assessment/create-assessment.ts
@@ -44,21 +44,13 @@ export const clickSection1 = async (
     const _date = faker.date.recent({ days: 1, refDate: Yesterday })
     await page.getByLabel('Date of current conviction').click()
     await fillDateOasys(page, '#itm_1_29', _date)
-    await page
-        .getByLabel(
-            'Does the current offence involve actual/attempted direct contact against a victim who was a stranger?'
-        )
-        .selectOption('1.44~YES')
+    await page.getByLabel('Have they ever committed a sexual or sexually motivated offence?').selectOption('1.30~YES')
+    await page.getByLabel('Does the current offence have a sexual motivation?').selectOption('1.41~YES')
     await page.getByLabel('Date of most recent sanction involving a sexual/sexually motivated offence').click()
     await fillDateOasys(page, '#itm_1_33', _date)
     await page
         .getByLabel('Number of previous/current sanctions involving contact adult sexual/sexually motivated offences')
         .fill('1')
-    await page
-        .getByLabel(
-            'Number of previous/current sanctions involving direct contact child sexual/sexually motivated offences'
-        )
-        .fill('0')
     await page
         .getByLabel(
             'Number of previous/current sanctions involving direct contact child sexual/sexually motivated offences'

--- a/steps/oasys/layer3-assessment/sign-and-lock.ts
+++ b/steps/oasys/layer3-assessment/sign-and-lock.ts
@@ -5,6 +5,7 @@ export const signAndlock = async (page: Page) => {
     await page.locator('#B1720617953204991').click()
     await page.getByRole('button', { name: 'Sign & Lock' }).click()
     await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
+    await page.locator('[value="Continue with Signing"]').click()
     await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
     await page.locator('#searchtop > h2').isVisible({ timeout: 15000 })
     await expect(page.locator('#searchtop > h2')).toHaveText('Task Manager')

--- a/test-data-setup/create-case/create-case.spec.ts
+++ b/test-data-setup/create-case/create-case.spec.ts
@@ -14,6 +14,7 @@ import { addLayer3AssessmentNeeds } from '../../steps/oasys/layer3-assessment/cr
 import { addCourtHearing } from '../../steps/court-case/add-court-hearing'
 
 test('Create a case in multiple systems', async ({ page }) => {
+    test.slow()
     const person = deliusPerson()
 
     if (process.env.CREATE_DELIUS_RECORD === 'true') {


### PR DESCRIPTION
Resolved the issue causing the test data setup failure for OASys assessment creation in the end-to-end (E2E) tests. The fix ensures that the OASys assessment creation process completes successfully, allowing the est Data Setup Failure to run without errors.