### PR TITLE
PI-2285: Add End2End Test for ARNS Endpoint Handling of Restricted Delius Cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,7 @@ jobs:
           RESETTLEMENT_PASSPORT_AND_DELIUS_API: https://resettlement-passport-and-delius-dev.hmpps.service.justice.gov.uk
           CVL_URL: https://create-and-vary-a-licence-test2.hmpps.service.justice.gov.uk
           CVL_API: https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk
+          ARNS_API: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
           CAS2_SHORT_TERM_ACCOMMODATION_URL: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk
           CAS3_TRANSITIONAL_ACCOMMODATION_URL: https://transitional-accommodation-dev.hmpps.service.justice.gov.uk
           TIER_UI_URL: https://tier-dev.hmpps.service.justice.gov.uk

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ MANAGE_POM_CASES_URL=https://dev.moic.service.justice.gov.uk
 
 CVL_URL=https://create-and-vary-a-licence-test2.hmpps.service.justice.gov.uk
 CVL_API=https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk
+ARNS_API=https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
 
 TIER_UI_URL=https://tier-dev.hmpps.service.justice.gov.uk
 

--- a/steps/api/arns/arns-api.ts
+++ b/steps/api/arns/arns-api.ts
@@ -1,0 +1,17 @@
+import { type APIRequestContext, request } from '@playwright/test'
+import { getToken } from '../auth/get-token'
+
+async function getContext(): Promise<APIRequestContext> {
+    const token = await getToken()
+    return request.newContext({
+        baseURL: process.env.ARNS_API,
+        extraHTTPHeaders: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+    })
+}
+
+export async function getRisksFromArns(crn: string) {
+    return await (await getContext()).get(`/risks/crn/${crn}`)
+}

--- a/steps/delius/restriction/create-restrictions.ts
+++ b/steps/delius/restriction/create-restrictions.ts
@@ -2,22 +2,22 @@ import { expect, Page } from '@playwright/test'
 import { selectOption, selectOptionAndWait } from '../utils/inputs'
 
 export async function createRestrictions(page: Page, args: { crn: string; users: string[] }) {
-    await page.click('#linkNavigation1DataMaintenance')
-    await page.getByTitle('Select this option to manage offender restrictions.').click()
-    await page.fill('#restrictionListForm\\:CRN', args.crn)
-    await page.click('#restrictionListForm\\:searchButton')
-    await page.locator('#restrictionListForm\\:OffenderName').isVisible()
+    await page.click('#navigation-include\\:linkNavigation1DataMaintenance')
+    await page.getByTitle('Select this option to manage Person restrictions.').click()
+    await page.fill('#crn\\:inputText', args.crn)
+    await page.click('#crn\\:commandButton')
+    await page.locator('#offenderName\\:outputText').isVisible()
 
     for (const username of args.users) {
-        await page.click('#restrictionListForm\\:insertRestriction')
+        await page.click('#insertRestriction')
         await expect(page).toHaveTitle('Add Restriction')
 
-        await page.fill('#UserID', username)
+        await page.fill('#search\\:inputText', username)
         await page.getByTitle('Select to locate the user').click()
-        await selectOption(page, '#RestrictionReason', 'Other')
-        await selectOptionAndWait(page, '#TransferToTrust', 'North East Region')
-        await selectOptionAndWait(page, '#RestrictionStartTeam', 'Automated Allocation Team')
-        await selectOption(page, '#RestrictionStartOfficer', 'Handover, Calculation')
+        await selectOption(page, '#restrictionReason\\:selectOneMenu', 'Other')
+        await selectOptionAndWait(page, '#transferToTrust\\:selectOneMenu', 'North East Region')
+        await selectOptionAndWait(page, '#restrictionStartTeam\\:selectOneMenu', 'Automated Allocation Team')
+        await selectOption(page, '#restrictionStartOfficer\\:selectOneMenu', 'Handover, Calculation')
         await page.click('input.btn-primary')
         await page.locator('div.prompt-warning').isVisible()
         await page.click('input.btn-primary')

--- a/tests/arns-and-delius/restricted-access.spec.ts
+++ b/tests/arns-and-delius/restricted-access.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+import { login as deliusLogin } from '../../steps/delius/login'
+import { login as hmppsLogin } from '../../steps/hmpps-auth/login'
+import { createOffender } from '../../steps/delius/offender/create-offender'
+import { deliusPerson } from '../../steps/delius/utils/person'
+import { createRestrictions } from '../../steps/delius/restriction/create-restrictions.js'
+import { getRisksFromArns } from '../../steps/api/arns/arns-api.js'
+
+test('Verify ARNS endpoint returns 403 for restricted Delius case', async ({ page }) => {
+    // Login to NDelius and create an offender
+    await hmppsLogin(page)
+    await deliusLogin(page)
+    const person = deliusPerson()
+    const crn: string = await createOffender(page, { person })
+
+    // Set restriction as test user will no longer have access
+    await page.locator('a', { hasText: 'National search' }).click()
+    await expect(page).toHaveTitle(/National Search/)
+    await createRestrictions(page, { crn, users: ['NDELIUS01'] })
+
+    // Call the arns-api to verify access restriction
+    const response = await getRisksFromArns(crn)
+    const responseBody = await response.json()
+
+    // Verify that arns-api returns 403 as the case has a restriction
+    expect(response.status()).toEqual(403)
+    expect(responseBody.developerMessage).toContain(`User does not have permission to access offender with CRN ${crn}`)
+})


### PR DESCRIPTION
**PR Summary:**

This PR introduces a new End2End test to validate the behavior of the ARNS endpoint when handling restricted Delius cases. 

The test scenario is structured as follows:

1. Log into NDelius and create an offender record 
2. Set access restrictions within the test environment to simulate restricted access conditions for specific users.
3. Initiate a request to the ARNS API using the e2e client, which internally calls arns-and-delius/users/access.
4. Verifies that the ARNS endpoint correctly returns a 403 status code, indicating access denial for restricted Delius cases.
5. Check the response body to ensure it contains the expected developer message indicating the reason for access restriction.

This new test ensures the test coverage for access control mechanisms between Delius and ARNS systems, ensuring compliance and security of offender data access in restricted scenarios.