### PR TITLE
PI-2295-new: Added automation test for Accredited programmes and OASys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
           # URLs
           DELIUS_URL: https://ndelius.test.probation.service.justice.gov.uk
           WORKFORCE_URL: https://workforce-management-dev.hmpps.service.justice.gov.uk
+          ACCREDITED_PROGRAMMES_URL: https://accredited-programmes-dev.hmpps.service.justice.gov.uk
           DPS_URL: https://digital-dev.prison.service.justice.gov.uk
           PRISONER_PROFILE_URL: https://prisoner-dev.digital.prison.service.justice.gov.uk
           AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk
@@ -139,6 +140,8 @@ jobs:
           OASYS_PASSWORD_OPD: ${{ secrets.E2E_OASYS_PASSWORD_OPD }}
           OASYS_USERNAME_APPROVEDPSOROLE: AUTOMATEDTESTUSER5
           OASYS_PASSWORD_APPROVEDPSOROLE: ${{ secrets.E2E_OASYS_PASSWORD_APPROVEDPSOROLE }}
+          OASYS_USERNAME_ACCREDITED_PROGRAMMES: AUTOMATEDTESTUSER6
+          OASYS_PASSWORD_ACCREDITED_PROGRAMMES: ${{ secrets.E2E_OASYS_PASSWORD_ACCREDITED_PROGRAMMES }}
           CONSIDER_A_RECALL_MRD_USERNAME: ${{ secrets.E2E_CONSIDER_RECALL_MRD_USERNAME }}
           CONSIDER_A_RECALL_MRD_PASSWORD: ${{ secrets.E2E_CONSIDER_RECALL_MRD_PASSWORD }}
 

--- a/steps/accredited-programmes/application.ts
+++ b/steps/accredited-programmes/application.ts
@@ -1,28 +1,5 @@
 import { expect, Page } from '@playwright/test'
-import { faker } from '@faker-js/faker'
-import { getDate, getYear, subMonths } from 'date-fns'
 import { format } from 'date-fns'
-// export async function submitApplication(page: Page, nomisId: string) {
-//     await findProgrammeAndMakeReferral(page, nomisId)
-//
-//     await startApplication(page)
-//     await searchForPerson(page, nomisId)
-//     await confirmEligibilityAndConsent(page)
-//     await addReferrerDetails(page)
-//     await checkInformation(page)
-//     await addPersonalInformation(page)
-//     await addAddressInformation(page)
-//     await addEqualityInformation(page)
-//     await addPreferredAreas(page)
-//     await confirmFunding(page)
-//     await addHealthNeeds(page)
-//     await riskToSelf(page)
-//     await riskToOthers(page)
-//     await addOffences(page)
-//     await hdcDetails(page)
-//     await checkAnswers(page)
-//     await expect(page.getByRole('heading', { name: 'Application complete' })).toBeVisible()
-// }
 
 export async function findProgrammeAndMakeReferral(page: Page, nomisId: string) {
     await page.getByRole('link', { name: 'Find a programme and make a referral' }).click()
@@ -30,56 +7,43 @@ export async function findProgrammeAndMakeReferral(page: Page, nomisId: string) 
     await page.getByRole('link', { name: 'Becoming New Me Plus: sexual offence' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence/)
     await page.getByRole('link', { name: 'Whatton (HMP)' }).click()
-    // await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence, Whatton (HMP)/)
     await expect(page).toHaveTitle(
         /HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence, Whatton \(HMP\)/
     )
-
     await page.getByRole('button', { name: /Make a referral/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
-
     await page.getByRole('button', { name: 'Start now' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Enter the person's identifier/)
-
     await page.getByLabel("Enter the prison number. We'll import their details into your application.").fill(nomisId)
-    // await page.locator('#prisonNumber').fill(nomisId)
     await page.getByRole('button', { name: /Continue/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Confirm personal details/)
-
     await page.getByRole('button', { name: /Continue/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
-
     await page.getByRole('link', { name: 'Review Accredited Programme history' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Accredited Programme history/)
     await page.getByRole('button', { name: /Return to tasklist/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
     await expect(page.locator('[data-testid="programme-history-tag"]')).toContainText('Completed')
-
     await page.getByRole('link', { name: 'Confirm the OASys information' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Confirm the OASys information/)
     await page.getByRole('checkbox', { name: /I confirm that the OASys information is up to date./ }).click()
     await page.getByRole('button', { name: /Continue/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
     await expect(page.locator('[data-testid="confirm-oasys-tag"]')).toContainText('Completed')
-
     await page.getByRole('link', { name: 'Add additional information' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Add additional information/)
     await page.getByLabel('Provide additional information').fill('Test additional information')
     await page.getByRole('button', { name: /Continue/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
     await expect(page.locator('[data-testid="additional-information-tag"]')).toContainText('Completed')
-
     await page.getByRole('link', { name: 'Check answers and submit' }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Check your answers/)
     await page.getByLabel('I confirm the information I have provided is complete, accurate and up to date.').check()
     await page.getByRole('button', { name: /Submit referral/ }).click()
-
     await expect(page.locator('h1')).toContainText('Referral complete')
     await page.getByRole('button', { name: /Go to my referrals/ }).click()
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - My referrals/)
 }
-export const oasysImportDateText = '[data-testid="imported-from-text"]'
-export const apFormattedTodayDate = format(new Date(), 'd MMMM yyyy')
 
 export async function clickOnOffenderLink(page: Page, linkName: string, fullName: string) {
     // Click on 'Date referred' link first
@@ -122,3 +86,6 @@ export async function assertRoSHRiskTable(page: Page, assertions: RoSHRiskAssert
         await page.waitForSelector(`${selector}:not(.rosh-table__cell--unknown):has-text("${expectedValue}")`)
     }
 }
+
+export const oasysImportDateText = '[data-testid="imported-from-text"]'
+export const apFormattedTodayDate = format(new Date(), 'd MMMM yyyy')

--- a/steps/accredited-programmes/application.ts
+++ b/steps/accredited-programmes/application.ts
@@ -1,0 +1,124 @@
+import { expect, Page } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import { getDate, getYear, subMonths } from 'date-fns'
+import { format } from 'date-fns'
+// export async function submitApplication(page: Page, nomisId: string) {
+//     await findProgrammeAndMakeReferral(page, nomisId)
+//
+//     await startApplication(page)
+//     await searchForPerson(page, nomisId)
+//     await confirmEligibilityAndConsent(page)
+//     await addReferrerDetails(page)
+//     await checkInformation(page)
+//     await addPersonalInformation(page)
+//     await addAddressInformation(page)
+//     await addEqualityInformation(page)
+//     await addPreferredAreas(page)
+//     await confirmFunding(page)
+//     await addHealthNeeds(page)
+//     await riskToSelf(page)
+//     await riskToOthers(page)
+//     await addOffences(page)
+//     await hdcDetails(page)
+//     await checkAnswers(page)
+//     await expect(page.getByRole('heading', { name: 'Application complete' })).toBeVisible()
+// }
+
+export async function findProgrammeAndMakeReferral(page: Page, nomisId: string) {
+    await page.getByRole('link', { name: 'Find a programme and make a referral' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Find an Accredited Programme/)
+    await page.getByRole('link', { name: 'Becoming New Me Plus: sexual offence' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence/)
+    await page.getByRole('link', { name: 'Whatton (HMP)' }).click()
+    // await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence, Whatton (HMP)/)
+    await expect(page).toHaveTitle(
+        /HMPPS Accredited Programmes - Becoming New Me Plus: sexual offence, Whatton \(HMP\)/
+    )
+
+    await page.getByRole('button', { name: /Make a referral/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
+
+    await page.getByRole('button', { name: 'Start now' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Enter the person's identifier/)
+
+    await page.getByLabel("Enter the prison number. We'll import their details into your application.").fill(nomisId)
+    // await page.locator('#prisonNumber').fill(nomisId)
+    await page.getByRole('button', { name: /Continue/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Confirm personal details/)
+
+    await page.getByRole('button', { name: /Continue/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
+
+    await page.getByRole('link', { name: 'Review Accredited Programme history' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Accredited Programme history/)
+    await page.getByRole('button', { name: /Return to tasklist/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
+    await expect(page.locator('[data-testid="programme-history-tag"]')).toContainText('Completed')
+
+    await page.getByRole('link', { name: 'Confirm the OASys information' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Confirm the OASys information/)
+    await page.getByRole('checkbox', { name: /I confirm that the OASys information is up to date./ }).click()
+    await page.getByRole('button', { name: /Continue/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
+    await expect(page.locator('[data-testid="confirm-oasys-tag"]')).toContainText('Completed')
+
+    await page.getByRole('link', { name: 'Add additional information' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Add additional information/)
+    await page.getByLabel('Provide additional information').fill('Test additional information')
+    await page.getByRole('button', { name: /Continue/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Make a referral/)
+    await expect(page.locator('[data-testid="additional-information-tag"]')).toContainText('Completed')
+
+    await page.getByRole('link', { name: 'Check answers and submit' }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Check your answers/)
+    await page.getByLabel('I confirm the information I have provided is complete, accurate and up to date.').check()
+    await page.getByRole('button', { name: /Submit referral/ }).click()
+
+    await expect(page.locator('h1')).toContainText('Referral complete')
+    await page.getByRole('button', { name: /Go to my referrals/ }).click()
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - My referrals/)
+}
+export const oasysImportDateText = '[data-testid="imported-from-text"]'
+export const apFormattedTodayDate = format(new Date(), 'd MMMM yyyy')
+
+export async function clickOnOffenderLink(page: Page, linkName: string, fullName: string) {
+    // Click on 'Date referred' link first
+    await page.getByRole('link', { name: linkName }).click()
+
+    // Get the link with person's full name
+    const nameLink = await page.getByRole('link', { name: fullName })
+
+    // Check if the link is visible
+    if (!(await nameLink.isVisible())) {
+        // If not visible, click 'Date referred' again
+        await page.getByRole('link', { name: linkName }).click()
+    }
+
+    // Click on the link with person's full name
+    await nameLink.click()
+}
+
+interface RoSHRiskAssertion {
+    riskToChildren: string
+    riskToPublic: string
+    riskToKnownAdult: string
+    riskToStaff: string
+    riskToPrisoners: string
+}
+export async function assertRoSHRiskTable(page: Page, assertions: RoSHRiskAssertion) {
+    const selectors = {
+        riskToChildren: 'tbody.govuk-table__body tr.govuk-table__row:nth-child(1) td.govuk-table__cell',
+        riskToPublic: 'tbody.govuk-table__body tr.govuk-table__row:nth-child(2) td.govuk-table__cell',
+        riskToKnownAdult: 'tbody.govuk-table__body tr.govuk-table__row:nth-child(3) td.govuk-table__cell',
+        riskToStaff: 'tbody.govuk-table__body tr.govuk-table__row:nth-child(4) td.govuk-table__cell',
+        riskToPrisoners: 'tbody.govuk-table__body tr.govuk-table__row:nth-child(5) td.govuk-table__cell',
+    }
+
+    for (const key of Object.keys(assertions)) {
+        const expectedValue = assertions[key as keyof RoSHRiskAssertion]
+        const selector = selectors[key as keyof typeof selectors]
+
+        // Wait for the selector to appear and check its inner text against expectedValue
+        await page.waitForSelector(`${selector}:not(.rosh-table__cell--unknown):has-text("${expectedValue}")`)
+    }
+}

--- a/steps/accredited-programmes/login.ts
+++ b/steps/accredited-programmes/login.ts
@@ -1,0 +1,10 @@
+import { expect, type Page } from '@playwright/test'
+
+export const login = async (page: Page) => {
+    await page.goto(process.env.ACCREDITED_PROGRAMMES_URL)
+    await expect(page).toHaveTitle(/HMPPS Digital Services - Sign in/)
+    await page.fill('#username', process.env.DPS_USERNAME!)
+    await page.fill('#password', process.env.DPS_PASSWORD!)
+    await page.click('#submit')
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Home/)
+}

--- a/steps/cas1-approved-premises/applications/edit-risk-information-offence-analysis.ts
+++ b/steps/cas1-approved-premises/applications/edit-risk-information-offence-analysis.ts
@@ -2,7 +2,7 @@ import { type Page, expect } from '@playwright/test'
 
 export const verifyOffenceAnalysisIsAsPerOASys = async (page: Page) => {
     await expect(page.getByLabel('Offence analysis')).toContainText(
-        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'HRosh to Partners, medium to male peers & children'"
+        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'High Rosh risk to Partners, Medium Rosh risk to male peers & children'"
     )
     await expect(page.getByLabel('Victim - perpetrator relationship')).toContainText(
         "OASys Question - 'Victim - perpetrator relationship' - Answer Input - 'Spouse/Partner - Live in"

--- a/steps/oasys/layer3-assessment/analysis-of-offences-layer3.ts
+++ b/steps/oasys/layer3-assessment/analysis-of-offences-layer3.ts
@@ -3,7 +3,7 @@ import { type Page, expect } from '@playwright/test'
 export const completeOffenceAnalysisYes = async (page: Page) => {
     await page.fill(
         '#textarea_2_1',
-        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'HRosh to Partners, medium to male peers & children'"
+        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'High Rosh risk to Partners, Medium Rosh risk to male peers & children'"
     )
     await page
         .locator('[for="itm_2_2_V2_WEAPON"]', { hasText: 'Carrying or using a weapon' })
@@ -82,7 +82,7 @@ export const completeOffenceAnalysisYes = async (page: Page) => {
 export const completeOffenceAnalysis = async (page: Page) => {
     await page.fill(
         '#textarea_2_1',
-        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'HRosh to Partners, medium to male peers & children'"
+        "OASys Question - '2.1 Brief offence(s) details (indicate what exactly happened, when, where and how)' - Answer Input - 'High Rosh risk to Partners, Medium Rosh risk to male peers & children'"
     )
     await page.locator("[value='Enter Victim Details']").click()
     await expect(page.locator('#R6262620100578238 > h2')).toHaveText('Victim’s Relationship to Perpetrator')

--- a/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
+++ b/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
@@ -30,7 +30,7 @@ import { completeReviewSentencePlan } from './review-sentenceplan'
 import { addYears } from 'date-fns'
 import { completeRoSHFullSec8RisksToIndvdl } from '../rosh-full-analysis-section8'
 
-export const createLayer3CompleteAssessment = async (page: Page, crn: string, person: Person) => {
+export const createLayer3CompleteAssessment = async (page: Page, crn: string, person: Person, nomisId?: string) => {
     let providerEstablishmentPageExists = false
 
     try {
@@ -55,6 +55,11 @@ export const createLayer3CompleteAssessment = async (page: Page, crn: string, pe
     await crnSearch(page, crn)
     // And I click on Create Offender button
     await clickCreateOffenderButton(page)
+    if (nomisId !== undefined) {
+        // Check if nomisId is provided
+        await page.locator('#P10_CMS_PRIS_NUMBER').fill(nomisId)
+        await page.locator('#B2777914628851790', { hasText: 'Save' }).click()
+    }
     // And I click on Create Assessment Button
     await clickCreateAssessmentButton(page)
     // And I say OK for CRN Amendment

--- a/steps/oasys/layer3-assessment/sign-and-lock.ts
+++ b/steps/oasys/layer3-assessment/sign-and-lock.ts
@@ -5,22 +5,44 @@ export const signAndlock = async (page: Page, role?: string) => {
     await page.locator('#B1720617953204991').click()
     await page.getByRole('button', { name: 'Sign & Lock' }).click()
     await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
+
+    // Click 'Continue with Signing' if role is not 'ApprovedPSORole'
     if (role !== 'ApprovedPSORole') {
-        await page.locator('[value="Continue with Signing"]').click()
-    }
-    const continueWithSigningBtn = page.locator('[value="Continue with Signing"]')
-
-    // Click 'Continue with Signing' if it is visible
-    if (await continueWithSigningBtn.isVisible()) {
-        await continueWithSigningBtn.click()
+        const continueButton = await page.locator('[value="Continue with Signing"]')
+        if (await continueButton.isVisible()) {
+            await continueButton.click()
+        }
     }
 
+    // Click 'Confirm Sign & Lock'
     await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
 
-    // If role is not 'ApprovedPSORole', verify the header is 'Task Manager'
+    // Verify the header is 'Task Manager' if role is not 'ApprovedPSORole'
     if (role !== 'ApprovedPSORole') {
         const taskManagerHeader = page.locator('#searchtop > h2')
-        await taskManagerHeader.isVisible({ timeout: 15000 })
+        await taskManagerHeader.waitFor({ timeout: 15000, state: 'visible' })
         await expect(taskManagerHeader).toHaveText('Task Manager')
     }
+    // await page.getByRole('link', { name: 'Summary Sheet' }).click()
+    // await page.locator('#B1720617953204991').click()
+    // await page.getByRole('button', { name: 'Sign & Lock' }).click()
+    // await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
+    // if (role !== 'ApprovedPSORole') {
+    //     await page.locator('[value="Continue with Signing"]').click()
+    // }
+    // const continueWithSigningBtn = page.locator('[value="Continue with Signing"]')
+    //
+    // // Click 'Continue with Signing' if it is visible
+    // if (await continueWithSigningBtn.isVisible()) {
+    //     await continueWithSigningBtn.click()
+    // }
+    //
+    // await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
+    //
+    // // If role is not 'ApprovedPSORole', verify the header is 'Task Manager'
+    // if (role !== 'ApprovedPSORole') {
+    //     const taskManagerHeader = page.locator('#searchtop > h2')
+    //     await taskManagerHeader.isVisible({ timeout: 15000 })
+    //     await expect(taskManagerHeader).toHaveText('Task Manager')
+    // }
 }

--- a/steps/oasys/layer3-assessment/sign-and-lock.ts
+++ b/steps/oasys/layer3-assessment/sign-and-lock.ts
@@ -23,26 +23,4 @@ export const signAndlock = async (page: Page, role?: string) => {
         await taskManagerHeader.waitFor({ timeout: 15000, state: 'visible' })
         await expect(taskManagerHeader).toHaveText('Task Manager')
     }
-    // await page.getByRole('link', { name: 'Summary Sheet' }).click()
-    // await page.locator('#B1720617953204991').click()
-    // await page.getByRole('button', { name: 'Sign & Lock' }).click()
-    // await page.getByRole('button', { name: 'Mark 1 to 9 as Missing' }).click()
-    // if (role !== 'ApprovedPSORole') {
-    //     await page.locator('[value="Continue with Signing"]').click()
-    // }
-    // const continueWithSigningBtn = page.locator('[value="Continue with Signing"]')
-    //
-    // // Click 'Continue with Signing' if it is visible
-    // if (await continueWithSigningBtn.isVisible()) {
-    //     await continueWithSigningBtn.click()
-    // }
-    //
-    // await page.getByRole('button', { name: 'Confirm Sign & Lock' }).click()
-    //
-    // // If role is not 'ApprovedPSORole', verify the header is 'Task Manager'
-    // if (role !== 'ApprovedPSORole') {
-    //     const taskManagerHeader = page.locator('#searchtop > h2')
-    //     await taskManagerHeader.isVisible({ timeout: 15000 })
-    //     await expect(taskManagerHeader).toHaveText('Task Manager')
-    // }
 }

--- a/steps/oasys/login.ts
+++ b/steps/oasys/login.ts
@@ -17,6 +17,7 @@ export enum UserType {
     Assessment,
     OPD,
     ApprovedPSORole,
+    AccreditedProgrammesAssessment,
 }
 
 const oasysUserConfig = (userType: UserType) => {
@@ -35,6 +36,11 @@ const oasysUserConfig = (userType: UserType) => {
             return {
                 username: process.env.OASYS_USERNAME_APPROVEDPSOROLE,
                 password: process.env.OASYS_PASSWORD_APPROVEDPSOROLE,
+            }
+        case UserType.AccreditedProgrammesAssessment:
+            return {
+                username: process.env.OASYS_USERNAME_ACCREDITED_PROGRAMMES,
+                password: process.env.OASYS_PASSWORD_ACCREDITED_PROGRAMMES,
             }
     }
 }

--- a/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
+++ b/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+import * as dotenv from 'dotenv'
+dotenv.config() // read environment variables into process.env
+import { login as deliusLogin } from '../../steps/delius/login'
+import { createOffender } from '../../steps/delius/offender/create-offender'
+import { deliusPerson } from '../../steps/delius/utils/person'
+import { login as oasysLogin, UserType } from '../../steps/oasys/login'
+import { createCustodialEvent } from '../../steps/delius/event/create-event'
+import { createAndBookPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api'
+import { data } from '../../test-data/test-data'
+import { createLayer3CompleteAssessment } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
+import { addLayer3AssessmentNeeds } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/add-layer3-needs'
+import { login as accreditedProgrammesLogin } from '../../steps/accredited-programmes/login.js'
+import {
+    apFormattedDate,
+    apFormattedTodayDate,
+    assertRoSHRiskTable,
+    clickOnOffenderLink,
+    findProgrammeAndMakeReferral,
+    oasysImportDateText,
+} from '../../steps/accredited-programmes/application.js'
+import { parseISO } from 'date-fns'
+
+import { apFormattedTodayDate as todaysDate } from '../../steps/accredited-programmes/application.js'
+
+const nomisIds = []
+// Set up the OASys record and confirm the details can be read in the Accredited Programmes
+test('View OASys assessments in Accredited Programmes service', async ({ page }) => {
+    test.slow() // increase the timeout - Delius/OASys/AP Applications can take a few minutes
+    // Given I create new Offender in nDelius
+    await deliusLogin(page)
+    const person = deliusPerson()
+    const crn = await createOffender(page, { person })
+
+    // And I create an event in nDelius
+    await createCustodialEvent(page, { crn, allocation: { team: data.teams.approvedPremisesTestTeam } })
+
+    // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
+    const { nomisId } = await createAndBookPrisoner(page, crn, person)
+    nomisIds.push(nomisId)
+    await oasysLogin(page, UserType.AccreditedProgrammesAssessment)
+    await createLayer3CompleteAssessment(page, crn, person, nomisId)
+    await addLayer3AssessmentNeeds(page)
+
+    // When I login in to Accredited Programmes Login
+
+    await accreditedProgrammesLogin(page)
+    await findProgrammeAndMakeReferral(page, nomisId)
+
+    // await page.getByRole('link', { name: 'My referrals' }).click()
+
+    await clickOnOffenderLink(page, 'Date referred', `${person.firstName} ${person.lastName}`)
+    await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Referral to Becoming New Me Plus: sexual offence/)
+
+    await page.getByRole('link', { name: 'Risks and needs' }).click()
+    await expect(page.locator(oasysImportDateText)).toHaveText(`Imported from OASys on ${todaysDate}.`)
+
+    await page.getByRole('link', { name: 'Risks and alerts' }).click()
+    await assertRoSHRiskTable(page, {
+        riskToChildren: 'Very high',
+        riskToPublic: 'Medium',
+        riskToKnownAdult: 'High',
+        riskToStaff: 'Medium',
+        riskToPrisoners: 'Not applicable',
+    })
+
+    // Section 2 - Offence analysis
+    await page.getByRole('link', { name: 'Section 2 - Offence analysis' }).click()
+
+    await expect(page.locator('[data-testid="brief-offence-details-summary-card"]')).toContainText(
+        'High Rosh risk to Partners, Medium Rosh risk to male peers & children'
+    )
+})
+
+test.afterAll(async () => {
+    for (const nomsId of nomisIds) {
+        await releasePrisoner(nomsId)
+    }
+})

--- a/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
+++ b/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
@@ -7,54 +7,46 @@ import { deliusPerson } from '../../steps/delius/utils/person'
 import { login as oasysLogin, UserType } from '../../steps/oasys/login'
 import { createCustodialEvent } from '../../steps/delius/event/create-event'
 import { createAndBookPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api'
-import { data } from '../../test-data/test-data'
 import { createLayer3CompleteAssessment } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
 import { addLayer3AssessmentNeeds } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/add-layer3-needs'
 import { login as accreditedProgrammesLogin } from '../../steps/accredited-programmes/login.js'
 import {
-    apFormattedDate,
-    apFormattedTodayDate,
     assertRoSHRiskTable,
     clickOnOffenderLink,
     findProgrammeAndMakeReferral,
     oasysImportDateText,
 } from '../../steps/accredited-programmes/application.js'
-import { parseISO } from 'date-fns'
 
 import { apFormattedTodayDate as todaysDate } from '../../steps/accredited-programmes/application.js'
 
 const nomisIds = []
-// Set up the OASys record and confirm the details can be read in the Accredited Programmes
+
 test('View OASys assessments in Accredited Programmes service', async ({ page }) => {
-    test.slow() // increase the timeout - Delius/OASys/AP Applications can take a few minutes
-    // Given I create new Offender in nDelius
+    test.slow()
+    // Step 1: Create new Offender & event in nDelius
     await deliusLogin(page)
     const person = deliusPerson()
     const crn = await createOffender(page, { person })
+    await createCustodialEvent(page, { crn })
 
-    // And I create an event in nDelius
-    await createCustodialEvent(page, { crn, allocation: { team: data.teams.approvedPremisesTestTeam } })
-
-    // And I create an entry in NOMIS (a corresponding person and booking in NOMIS)
+    // Step 2: Create an entry in NOMIS (a corresponding person and booking in NOMIS)
     const { nomisId } = await createAndBookPrisoner(page, crn, person)
     nomisIds.push(nomisId)
+
+    // Step 3: Create a Layer 3 Assessment in OASys
     await oasysLogin(page, UserType.AccreditedProgrammesAssessment)
     await createLayer3CompleteAssessment(page, crn, person, nomisId)
     await addLayer3AssessmentNeeds(page)
 
-    // When I login in to Accredited Programmes Login
-
+    // Step 4: Make referral in Accredited Programmes
     await accreditedProgrammesLogin(page)
     await findProgrammeAndMakeReferral(page, nomisId)
 
-    // await page.getByRole('link', { name: 'My referrals' }).click()
-
+    // Step 5: Verify OASys assessment data in Accredited Programmes service
     await clickOnOffenderLink(page, 'Date referred', `${person.firstName} ${person.lastName}`)
     await expect(page).toHaveTitle(/HMPPS Accredited Programmes - Referral to Becoming New Me Plus: sexual offence/)
-
     await page.getByRole('link', { name: 'Risks and needs' }).click()
     await expect(page.locator(oasysImportDateText)).toHaveText(`Imported from OASys on ${todaysDate}.`)
-
     await page.getByRole('link', { name: 'Risks and alerts' }).click()
     await assertRoSHRiskTable(page, {
         riskToChildren: 'Very high',
@@ -63,10 +55,7 @@ test('View OASys assessments in Accredited Programmes service', async ({ page })
         riskToStaff: 'Medium',
         riskToPrisoners: 'Not applicable',
     })
-
-    // Section 2 - Offence analysis
     await page.getByRole('link', { name: 'Section 2 - Offence analysis' }).click()
-
     await expect(page.locator('[data-testid="brief-offence-details-summary-card"]')).toContainText(
         'High Rosh risk to Partners, Medium Rosh risk to male peers & children'
     )


### PR DESCRIPTION
This pull request adds an end-to-end automation test to verify the integration between Accredited Programmes and OASys systems.

Implemented an automated test scenario covering the following steps:

1. Creation of a new offender and event in nDelius.
2. Creation of a corresponding person and booking in NOMIS.
3. Login to OASys T2 with UserType.AccreditedProgrammesAssessment.
4. Addition of NomisId to the offender in OASys.
5. Creation of a Layer 3 Assessment in OASys.
6. Login to Accredited Programmes.
7. Search for Nomis id.
8. Making a referral in Accredited Programmes.
9. Verification of OASys assessment data in Accredited Programmes service.