### PR TITLE
PI-2345: Implemented End2End test for Delius and SAR integration; reenabled PDF-related code for /create-pre-sentence-report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,8 @@ jobs:
           PREPARE_A_CASE_FOR_SENTENCE_URL: https://prepare-a-case-dev.apps.live-1.cloud-platform.service.justice.gov.uk
           PRISON_IDENTIFIER_AND_DELIUS_URL: https://prison-identifier-and-delius-dev.hmpps.service.justice.gov.uk
           MANAGE_A_SUPERVISION_URL: https://manage-a-supervision-dev.hmpps.service.justice.gov.uk
+          SUBJECT_ACCESS_REQUEST_URL: https://subject-access-request-dev.hmpps.service.justice.gov.uk
+
           # Credentials
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ ARNS_API=https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
 TIER_UI_URL=https://tier-dev.hmpps.service.justice.gov.uk
 
 PREPARE_A_CASE_FOR_SENTENCE_URL=https://prepare-a-case-dev.apps.live-1.cloud-platform.service.justice.gov.uk
-
 PRISON_IDENTIFIER_AND_DELIUS_URL=https://prison-identifier-and-delius-dev.hmpps.service.justice.gov.uk
+SUBJECT_ACCESS_REQUEST_URL=https://subject-access-request-dev.hmpps.service.justice.gov.uk
 ```
 
 ## Running Tests

--- a/steps/subject-access-request/application.ts
+++ b/steps/subject-access-request/application.ts
@@ -1,0 +1,37 @@
+import { expect, Page } from '@playwright/test'
+import { refreshUntil } from '../delius/utils/refresh.js'
+
+export async function requestSarReportForCrn(page: Page, crn: string) {
+    // Request a new SAR report
+    await page.getByRole('link', { name: 'Request a report' }).click()
+    await page.locator('#subject-id').fill(crn)
+    await page.getByRole('button', { name: /Confirm/ }).click()
+    await expect(page).toHaveTitle(/Subject Access Requests/)
+    await expect(page.locator('#main-content h1')).toHaveText('Enter details')
+
+    // Enter case reference number
+    await page.getByLabel('Case Reference Number').fill(crn)
+    await page.getByRole('button', { name: /Confirm/ }).click()
+    await expect(page.locator('#main-content h1')).toHaveText('Select Services')
+
+    // Select services
+    await page.getByRole('row', { name: 'Select keyworker-api' }).locator('label').click()
+    await page.getByRole('button', { name: /Confirm/ }).click()
+
+    // Confirm report details
+    await expect(page.locator('#main-content h1')).toHaveText('Please confirm report details')
+    await page.getByRole('button', { name: /Accept and create report/ }).click()
+    await expect(page.locator('#main-content h1')).toHaveText(`Your report request for ${crn} has been submitted`)
+
+    // View all reports
+    await page.getByRole('link', { name: /View all reports./ }).click()
+    await expect(page.locator('#main-content h1')).toHaveText('Subject Access Request Reports')
+
+    // Search for the report
+    await page.getByLabel('Find a report').fill(crn)
+    await page.getByRole('button', { name: /Search/ }).click()
+
+    // Refresh until the report is available
+    const sarReportTable = page.locator('[data-module="moj-sortable-table"]')
+    await refreshUntil(page, () => expect(sarReportTable).toContainText(/View report/))
+}

--- a/steps/subject-access-request/login.ts
+++ b/steps/subject-access-request/login.ts
@@ -1,0 +1,10 @@
+import { expect, type Page } from '@playwright/test'
+
+export const login = async (page: Page) => {
+    await page.goto(process.env.SUBJECT_ACCESS_REQUEST_URL)
+    await expect(page).toHaveTitle(/HMPPS Digital Services - Sign in/)
+    await page.fill('#username', process.env.DPS_USERNAME!)
+    await page.fill('#password', process.env.DPS_PASSWORD!)
+    await page.click('#submit')
+    await expect(page).toHaveTitle(/Subject Access Requests - Home/)
+}

--- a/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
+++ b/tests/pre-sentence-reports-to-delius/create-pre-sentence-report.spec.ts
@@ -8,6 +8,8 @@ import { data } from '../../test-data/test-data'
 import { faker } from '@faker-js/faker'
 import { findCourtReport } from '../../steps/delius/court-report/find-court-report'
 import { createDocumentFromTemplate } from '../../steps/delius/document/create-document'
+import { createSubjectAccessReport, getFileFromZip } from '../../steps/delius/document/subject-access-report.js'
+import { getPdfText } from '../../steps/delius/utils/pdf-utils.js'
 
 test('Create a short format pre-sentence report', async ({ page }) => {
     // Given a person with an event that has been adjourned for pre-sentence report,
@@ -101,10 +103,9 @@ test('Create a short format pre-sentence report', async ({ page }) => {
     // Then the document appears in the Delius document list
     await expect(page.locator('#documentTable\\:0\\:openExternalButton')).toContainText('open in pre-sentence service')
 
-    // TODO re-enable this once the SAR page is available in the new Delius UI
     // And the PDF appears in non-DRAFT form in the subject access report zip file
-    // await createSubjectAccessReport(page, crn, `downloads/${crn}-sar.zip`)
-    // const file = await getFileFromZip(`downloads/${crn}-sar.zip`, /.+\.pdf/)
-    // const pdfText = await getPdfText(file)
-    // expect(pdfText).not.toContain('DRAFT')
+    await createSubjectAccessReport(page, crn, `downloads/${crn}-sar.zip`)
+    const file = await getFileFromZip(`downloads/${crn}-sar.zip`, /.+\.pdf/)
+    const pdfText = await getPdfText(file)
+    expect(pdfText).not.toContain('DRAFT')
 })

--- a/tests/sar-and-delius/request-sar-report-for-a-crn.spec.ts
+++ b/tests/sar-and-delius/request-sar-report-for-a-crn.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+import * as dotenv from 'dotenv'
+dotenv.config() // read environment variables into process.env
+import { login as deliusLogin } from '../../steps/delius/login'
+import { createOffender } from '../../steps/delius/offender/create-offender'
+import { deliusPerson } from '../../steps/delius/utils/person'
+import { createAndBookPrisoner, releasePrisoner } from '../../steps/api/dps/prison-api'
+import { login as sarLogin } from '../../steps/subject-access-request/login'
+import { requestSarReportForCrn } from '../../steps/subject-access-request/application'
+import { getPdfText } from '../../steps/delius/utils/pdf-utils.js'
+import * as fs from 'fs'
+
+const nomisIds: string[] = []
+
+test('Verify SAR report correctly includes subject details from Delius using CRN', async ({ page }) => {
+    // Step 1: Log in to Delius and create a new offender
+    await deliusLogin(page)
+    const person = deliusPerson()
+    const crn = await createOffender(page, { person })
+
+    // Step 2: Create and book a prisoner in NOMIS
+    const { nomisId } = await createAndBookPrisoner(page, crn, person)
+    nomisIds.push(nomisId)
+
+    // Step 3: Log in to SAR and request a new SAR report
+    await sarLogin(page)
+    await requestSarReportForCrn(page, crn)
+
+    // Step 4: Verify the CRN and Person's full name appear in the SAR PDF
+    const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        page.locator('a', { hasText: 'View report' }).click(),
+    ])
+    await download.saveAs(`downloads/${crn}-sar.pdf`)
+    const pdfText = await getPdfText(await fs.promises.readFile(`downloads/${crn}-sar.pdf`))
+    expect(pdfText).toContain(crn)
+    expect(pdfText).toContain(person.firstName)
+    expect(pdfText).toContain(person.lastName)
+})
+
+test.afterAll(async () => {
+    // Clean up by releasing all booked prisoners
+    await Promise.all(nomisIds.map(nomisId => releasePrisoner(nomisId)))
+})


### PR DESCRIPTION
This PR includes the following changes:

**1. Reenabled subject access report zip file-Related Code for "create-pre-sentence-report" End-to-End test:**

- Restored the previously commented-out code for handling PDF generation and validation for the /create-pre-sentence-report endpoint.

**2. Implemented End-to-End Test for Delius and SAR Integration:**

Step 1: Log in to Delius and create a new offender.
Step 2: Create and book a prisoner in NOMIS.
Step 3: Log in to SAR and request a new SAR report.
Step 4: Verify that the CRN and the person’s full name appear in the SAR PDF.

Note: Delius and SAR End-to-End test will currently fail because the SAR PDF only displays the CRN. The verification for the person’s first name and last name is not yet implemented in the PDF. The assertions for checking the person's first name and last name should be commented out until this feature is implemented if want this test to pass.