### PR TITLE
PI-2411 - Update Refer and Monitor test data tests with latest Application Changes

### DIFF
--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -166,8 +166,6 @@ export const updateSAAppointmentLocation = async (
     NPSLocationToBeVerifiedInRAndM: string
 ) => {
     await referralProgress(page, referralRef)
-    // await page.getByRole('link', { name: 'View details or reschedule' }).click()
-
     await page.locator('[href$="progress"]', { hasText: 'Progress' }).click()
     await page.getByRole('link', { name: 'View details or reschedule' }).click()
 

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -168,7 +168,6 @@ export const updateSAAppointmentLocation = async (
     await referralProgress(page, referralRef)
     await page.locator('[href$="progress"]', { hasText: 'Progress' }).click()
     await page.getByRole('link', { name: 'View details or reschedule' }).click()
-
     await expect(page.locator('.govuk-heading-xl')).toContainText('View appointment details')
     await page.getByRole('link', { name: 'Change appointment details' }).click()
     await expect(page.locator('.govuk-heading-xl')).toContainText('Change appointment details')

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -65,19 +65,19 @@ export const navigateToNSIContactDetails = async (page: Page, crn: string, inclu
 
 export const navigateToNSIDetails = async (page: Page, crn: string, includeTerminatedNSI = false) => {
     await findOffenderByCRN(page, crn)
-    await page.click('#linkNavigation2EventList')
+    await page.click('#navigation-include\\:linkNavigation2EventList')
     await expect(page).toHaveTitle(/Events/)
     await page.locator('[title="View event"]', { hasText: 'View' }).click()
     await expect(page).toHaveTitle(/Event Details/)
-    await page.click('#linkNavigation3EventNsi')
+    await page.click('#navigation-include\\:linkNavigation3EventNsi')
     await expect(page).toHaveTitle(/Non Statutory Intervention List/)
     if (includeTerminatedNSI) {
-        await page.locator('#nsiListForm\\:ShowTerminated').selectOption({ label: 'Yes' })
+        await page.locator('#ShowTerminated\\:selectOneMenu').selectOption({ label: 'Yes' })
     }
-    await page.locator('#nsiListForm\\:nsiTable\\:tbody_element').getByRole('link', { name: 'view' }).click()
+    await page.locator('#nsiTable > tbody').getByRole('link', { name: 'view' }).click()
     await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details')
 }
-
+// #ShowTerminated\:selectOneMenu
 export const navigateToNSIDetailsFromPersonalDetails = async (page: Page, crn: string) => {
     await findOffenderByCRN(page, crn)
     await page.click('#navigation-include\\:linkNavigation2OffenderIndex')
@@ -95,6 +95,7 @@ export const rescheduleSupplierAssessmentAppointment = async (
     attended = true
 ) => {
     await referralProgress(page, referralRef)
+    await page.locator('[href$="progress"]', { hasText: 'Progress' }).click()
     await page.getByRole('link', { name: 'View details or reschedule' }).click()
     await expect(page.locator('.govuk-heading-xl')).toContainText('View appointment details')
     await page.getByRole('link', { name: 'Change appointment details' }).click()
@@ -109,13 +110,24 @@ export const rescheduleSupplierAssessmentAppointment = async (
     if (newAppointmentDate <= new Date()) {
         // add feedback
         await page.waitForURL(/service-provider\/referrals\/.*\/supplier-assessment\/post-assessment-feedback\/edit/)
-        await page.click(`input[value=${attended ? 'yes' : 'no'}]`)
+        if (!attended) {
+            // If not attended
+            await page.click(`input[value="no"]`)
+            await page.locator('#attendedNoRadio').click()
+        } else {
+            // If attended
+            await page.click(`input[value="yes"]`)
+        }
+
         await page.click('button.govuk-button')
 
         if (attended) {
             await page.waitForURL(
                 /service-provider\/referrals\/.*\/supplier-assessment\/post-assessment-feedback\/edit\/.*\/behaviour/
             )
+
+            // Was the person late?
+            await page.locator('#wasLateNoRadio').check()
 
             // What did you do in the session?
             await page.fill('#session-summary', 'A description of the behaviour')
@@ -124,15 +136,17 @@ export const rescheduleSupplierAssessmentAppointment = async (
             await page.fill('#session-response', 'A description of the behaviour')
 
             // Did anything concern you about the person
-            await page.locator('#notify-probation-practitioner-2').check()
+            await page.getByRole('checkbox', { name: 'No', exact: true }).check()
+
             await page.click('button.govuk-button')
         }
 
         await fillAndSaveIfTextBoxIsAvailable(
             page,
-            '#attendance-failure-information',
+            '#no-attendance-information',
             'Additional information of the person not attending the appointment',
-            'button.govuk-button'
+            'button.govuk-button',
+            '#noNotifyPPRadio'
         )
         await page.waitForURL(
             /service-provider\/referrals\/.*\/supplier-assessment\/post-assessment-feedback\/edit\/.*\/check-your-answers/
@@ -153,7 +167,11 @@ export const updateSAAppointmentLocation = async (
     NPSLocationToBeVerifiedInRAndM: string
 ) => {
     await referralProgress(page, referralRef)
+    // await page.getByRole('link', { name: 'View details or reschedule' }).click()
+
+    await page.locator('[href$="progress"]', { hasText: 'Progress' }).click()
     await page.getByRole('link', { name: 'View details or reschedule' }).click()
+
     await expect(page.locator('.govuk-heading-xl')).toContainText('View appointment details')
     await page.getByRole('link', { name: 'Change appointment details' }).click()
     await expect(page.locator('.govuk-heading-xl')).toContainText('Change appointment details')
@@ -182,7 +200,7 @@ export const verifySAApptmntLocationInDelius = async (
     await matchingContactRecord.locator('[title="Link to view the contact details."]').click()
 
     // Verify the Updated Appointment Location in Delius
-    const location = await page.locator('#searchContactForm\\:Location').textContent()
+    const location = await page.locator('#location\\:outputText').textContent()
     await expect(location).toBe(NPSOfficeLocationToBeVerified)
 }
 
@@ -190,11 +208,21 @@ export const fillAndSaveIfTextBoxIsAvailable = async (
     page: Page,
     textBoxLocator: string,
     textToBeEnteredInTextBox: string,
-    saveButtonLocator: string
+    saveButtonLocator: string,
+    radioButtonLocator?: string // Optional parameter
 ): Promise<void> => {
     const textBox = page.locator(textBoxLocator)
+
     if (await textBox.isVisible()) {
         await textBox.fill(textToBeEnteredInTextBox)
+
+        // If radioButtonLocator is provided, check if the radio button is visible and click it
+        if (radioButtonLocator) {
+            const radioButton = page.locator(radioButtonLocator)
+            if (await radioButton.isVisible()) {
+                await radioButton.click()
+            }
+        }
         await page.click(saveButtonLocator)
     }
 }

--- a/steps/delius/contact/find-contacts.ts
+++ b/steps/delius/contact/find-contacts.ts
@@ -77,7 +77,7 @@ export const navigateToNSIDetails = async (page: Page, crn: string, includeTermi
     await page.locator('#nsiTable > tbody').getByRole('link', { name: 'view' }).click()
     await expect(page.locator('#content > h1')).toHaveText('Non Statutory Intervention Details')
 }
-// #ShowTerminated\:selectOneMenu
+
 export const navigateToNSIDetailsFromPersonalDetails = async (page: Page, crn: string) => {
     await findOffenderByCRN(page, crn)
     await page.click('#navigation-include\\:linkNavigation2OffenderIndex')
@@ -137,7 +137,6 @@ export const rescheduleSupplierAssessmentAppointment = async (
 
             // Did anything concern you about the person
             await page.getByRole('checkbox', { name: 'No', exact: true }).check()
-
             await page.click('button.govuk-button')
         }
 

--- a/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
+++ b/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
@@ -38,7 +38,7 @@ export const createLayer3CompleteAssessment = async (page: Page, crn: string, pe
         await page.waitForSelector('#loginbodyheader > h2', { timeout: 5000 })
         providerEstablishmentPageExists =
             (await page.locator('#loginbodyheader > h2').innerText()) === 'Provider/Establishment'
-    } catch (error) {
+    } catch {
         // If the element is not found within the timeout, set providerEstablishmentPageExists to false
         console.error('Provider/Establishment page element not found within timeout.')
         providerEstablishmentPageExists = false

--- a/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
+++ b/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
@@ -38,7 +38,7 @@ export const createLayer3CompleteAssessment = async (page: Page, crn: string, pe
         await page.waitForSelector('#loginbodyheader > h2', { timeout: 5000 })
         providerEstablishmentPageExists =
             (await page.locator('#loginbodyheader > h2').innerText()) === 'Provider/Establishment'
-    } catch {
+    } catch (error) {
         // If the element is not found within the timeout, set providerEstablishmentPageExists to false
         console.error('Provider/Establishment page element not found within timeout.')
         providerEstablishmentPageExists = false

--- a/steps/referandmonitor/appointment.ts
+++ b/steps/referandmonitor/appointment.ts
@@ -4,7 +4,6 @@ import { addMinutes } from 'date-fns'
 import { get12Hour, getTimeOfDay } from '../delius/utils/date-time'
 import { refreshUntil } from '../delius/utils/refresh'
 import { fillAndSaveIfTextBoxIsAvailable } from '../delius/contact/find-contacts'
-import { faker } from '@faker-js/faker'
 
 export const createSupplierAssessmentAppointment = async (
     page: Page,

--- a/steps/referandmonitor/appointment.ts
+++ b/steps/referandmonitor/appointment.ts
@@ -4,6 +4,7 @@ import { addMinutes } from 'date-fns'
 import { get12Hour, getTimeOfDay } from '../delius/utils/date-time'
 import { refreshUntil } from '../delius/utils/refresh'
 import { fillAndSaveIfTextBoxIsAvailable } from '../delius/contact/find-contacts'
+import { faker } from '@faker-js/faker'
 
 export const createSupplierAssessmentAppointment = async (
     page: Page,
@@ -15,6 +16,7 @@ export const createSupplierAssessmentAppointment = async (
     await referralProgress(page, referralRef)
 
     // Navigate to the SA appointment form
+    await page.locator('[href$="progress"]', { hasText: 'Progress' }).click()
     await page.locator('a.govuk-link', { hasText: 'Schedule' }).click()
     await expect(page).toHaveURL(/service-provider\/referrals\/.*\/supplier-assessment\/schedule\/.*\/details/)
 

--- a/steps/referandmonitor/referral.ts
+++ b/steps/referandmonitor/referral.ts
@@ -11,7 +11,7 @@ export const referralProgress = async (page: Page, referralRef: string) => {
 
     // Find the correct referral using the Referral Reference
     await page.locator('tr', { hasText: referralRef }).locator('a.govuk-link').click()
-    await expect(page).toHaveURL(/service-provider\/referrals\/.*\/progress/)
+    await expect(page).toHaveURL(/service-provider\/referrals\/.*\/details/)
 }
 
 export const makeReferral = async (page: Page, crn: string) => {
@@ -83,7 +83,7 @@ export const makeReferral = async (page: Page, crn: string) => {
     // Confirm the relevant sentence
     await page.locator('text=Confirm the relevant sentence for the Accommodation referral').click()
     await expect(page).toHaveURL(/referrals\/.*\/relevant-sentence/)
-    await page.locator('input[name="relevant-sentence-id"]').check()
+    await page.locator('input[name="relevant-sentence-id"]').first().check()
     await page.locator('text=Save and continue').click()
     await expect(page).toHaveURL(/referrals\/.*\/service-category\/.*\/desired-outcomes/)
 
@@ -145,24 +145,24 @@ export const assignReferral = async (page: Page, referralRef: string) => {
     // Find the correct referral using the Referral Reference
     await page.locator('#case-search-text').fill(referralRef)
     await page.locator('.govuk-button').click()
-
     await page.locator('tr', { hasText: referralRef }).locator('a.govuk-link').click()
     await expect(page).toHaveURL(/referrals\/.*\/details/)
 
     // Add the caseworker email address
     await page.fill('#email', process.env.REFERANDMONITOR_SUPPLIER_USERNAME!)
 
-    await page.locator('text=Save and continue').click()
+    // await page.locator('text=Save and continue').click()
+    await page.getByRole('button', { name: /Save and continue/ }).click()
     await expect(page).toHaveURL(/service-provider\/referrals\/.*\/assignment\/.*\/check/)
 
-    await page.locator('text=Confirm assignment').click()
+    // await page.locator('text=Confirm assignment').click()
+    await page.getByRole('button', { name: /Confirm assignment/ }).click()
     await expect(page).toHaveURL(/service-provider\/referrals\/.*\/assignment\/confirmation/)
-
-    await page.locator('text=Return to dashboard').click()
+    await page.getByRole('link', { name: 'Return to dashboard' }).click()
     await expect(page).toHaveURL(/service-provider\/dashboard\/unassigned-cases/)
 }
 
-export const cancelReferral = async (page: Page, referralRef: string) => {
+export const withdrawReferral = async (page: Page, referralRef: string) => {
     // Navigate to list of available interventions
     await page.locator('a', { hasText: 'Open cases' }).click()
     await expect(page).toHaveURL(/probation-practitioner\/dashboard\/open-cases/)
@@ -181,11 +181,13 @@ export const cancelReferral = async (page: Page, referralRef: string) => {
     }
 
     await expect(page).toHaveURL(/probation-practitioner\/referrals\/.*\/progress/)
-    await page.locator('a', { hasText: 'Cancel this referral' }).click()
-    await expect(page).toHaveURL(/probation-practitioner\/referrals\/.*\/cancellation\/.*\/reason/)
-    await page.locator('label', { hasText: "Probation practitioner's professional judgement" }).click()
-    await page.locator('button.govuk-button').click()
-    await page.locator('p', { hasText: 'Are you sure you want to cancel this referral?' })
-    await page.locator('button.govuk-button').click()
-    await expect(page.locator('h1.govuk-panel__title')).toContainText('This referral has been cancelled')
+    await page.getByRole('button', { name: 'Withdraw referral' }).click()
+    await expect(page).toHaveURL(/probation-practitioner\/referrals\/.*\/withdrawal\/.*\/reason/)
+    await page.getByLabel('Work, caring commitments, or').check()
+    await page.locator('#withdrawal-comments-WOR').fill('Work and caring commitments')
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page).toHaveURL(/probation-practitioner\/referrals\/.*\/withdrawal\/.*\/check-your-answers/)
+    await page.getByLabel('Yes').check()
+    await page.getByRole('button', { name: 'Confirm and send' }).click()
+    await expect(page.locator('h1.govuk-panel__title')).toContainText('Referral withdrawn')
 }

--- a/steps/referandmonitor/referral.ts
+++ b/steps/referandmonitor/referral.ts
@@ -150,12 +150,9 @@ export const assignReferral = async (page: Page, referralRef: string) => {
 
     // Add the caseworker email address
     await page.fill('#email', process.env.REFERANDMONITOR_SUPPLIER_USERNAME!)
-
-    // await page.locator('text=Save and continue').click()
     await page.getByRole('button', { name: /Save and continue/ }).click()
     await expect(page).toHaveURL(/service-provider\/referrals\/.*\/assignment\/.*\/check/)
 
-    // await page.locator('text=Confirm assignment').click()
     await page.getByRole('button', { name: /Confirm assignment/ }).click()
     await expect(page).toHaveURL(/service-provider\/referrals\/.*\/assignment\/confirmation/)
     await page.getByRole('link', { name: 'Return to dashboard' }).click()

--- a/test-data-setup/refer-and-monitor-functional-tests/reschedule-appointment.spec.ts
+++ b/test-data-setup/refer-and-monitor-functional-tests/reschedule-appointment.spec.ts
@@ -24,7 +24,7 @@ import { DeliusDateFormatter } from '../../steps/delius/utils/date-time'
 import { createAndAssignReferral } from '../../tests/refer-and-monitor-and-delius/common'
 import { createContact } from '../../steps/delius/contact/create-contact'
 import { deliusPerson } from '../../steps/delius/utils/person'
-import { cancelReferral } from '../../steps/referandmonitor/referral'
+import { withdrawReferral } from '../../steps/referandmonitor/referral'
 
 test.beforeEach(async ({ page }) => {
     await loginDelius(page)
@@ -362,7 +362,7 @@ test('Perform supplier assessment appointment scheduling with conflicting appoin
     )
 })
 
-test('Verify Referral Cancellation by Probation Practitioner and its Reflection in Delius', async ({ page }) => {
+test('Verify Referral withdrawal by Probation Practitioner and its Reflection in Delius', async ({ page }) => {
     test.slow()
 
     // Create offender, community event, and requirement
@@ -377,10 +377,12 @@ test('Verify Referral Cancellation by Probation Practitioner and its Reflection 
     // Find the correct referral using the Referral Reference & Cancel the Referral
     await logoutRandM(page)
     await loginAsPractitioner(page)
-    await cancelReferral(page, referralRef)
+    await withdrawReferral(page, referralRef)
 
     // Verify the referral cancellation should reflect in Delius
     await loginDelius(page)
     await navigateToNSIDetails(page, crn, true)
-    await expect(page.locator('div:right-of(:text("Outcome:"))').first()).toContainText('CRS Referral Cancelled')
+    await expect(page.locator('#j_idt808\\:outputText')).toContainText(
+        'Did not start (Work, Caring Commitments, Long-term Sickness)'
+    )
 })


### PR DESCRIPTION
This pull request covers the fixes for the following tests:

- Reschedule Supplier Assessment Appointment to Future Date
- Reschedule Supplier Assessment Appointment to Past Date/Time with Attendance Set to Yes and Notify Practitioner Set to No
- Reschedule Supplier Assessment Appointment to Past Date/Time with Attendance Set to No
- Reschedule Supplier Assessment Appointment to Past Date/Time with Attendance Set to Yes and Notify Practitioner Set to Yes
- Update Future Dated Supplier Assessment Appointment Location in Refer and Monitor and Verify in Delius
- Perform Supplier Assessment Appointment Scheduling with Conflicting Appointment in Delius
- Verify Referral Cancellation by Probation Practitioner and its Reflection in Delius