### PR TITLE
Update offence code in court-case-service testdata And FIx K8s Pod deletion logic

### DIFF
--- a/steps/court-case/hearing-data.ts
+++ b/steps/court-case/hearing-data.ts
@@ -62,13 +62,13 @@ export const hearingData = (person: Person, courtCode: string = SHEFFIELD_COURT.
                             {
                                 id: '0c932f0c-282b-418e-b294-8966498b1eef',
                                 offenceLegislation:
-                                    'Contrary to section 20 of the Offences Against the Person Act 1861.',
-                                offenceTitle: 'Wound / inflict grievous bodily harm without intent',
+                                    'Contrary to section 47 of the Offences Against the Person Act 1861.',
+                                offenceTitle: 'Assault a person thereby occasioning them actual bodily harm',
                                 wording:
-                                    'on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith',
+                                    'On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm',
                                 listingNumber: 3,
-                                offenceDefinitionId: '1136fd5e-d9d3-4df6-a6a6-a79c8530379f',
-                                offenceCode: 'CJO3523',
+                                offenceDefinitionId: 'a86115ce-b611-38e3-8300-1d3d653f5b3a',
+                                offenceCode: 'OF61102',
                                 plea: {
                                     pleaValue: 'not guilty',
                                 },

--- a/steps/k8s/k8s-utils.ts
+++ b/steps/k8s/k8s-utils.ts
@@ -94,7 +94,7 @@ export async function runPod(
     console.log('Started pod:', podName)
     try {
         const started = Date.now()
-        while (Date.now() - started > 30_000) {
+        while (Date.now() - started < 30_000) {
             const { body: pod } = await coreV1Api.readNamespacedPod(podName, namespace)
             if (pod.status?.phase === 'Succeeded') break
             if (pod.status?.phase === 'Failed') throw new Error('Pod failed.')


### PR DESCRIPTION
- Update offence code in court-case-service testdata

This is because the current offence code can't be found when court-case-service makes an api call for it.

-- 

- Fix pod timeout threshold ... allow pod to take up to 30 seconds long so that it can have enough time to run its commands