### PR TITLE
PI-2460 - Fix for End-to-end test for oasys-and-delius is not triggering the counter-signing request

### DIFF
--- a/steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self.ts
+++ b/steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self.ts
@@ -2,13 +2,13 @@ import { type Page, expect } from '@playwright/test'
 
 export const verifyRiskToSelfIsAsPerOASys = async (page: Page) => {
     await expect(page.getByLabel('Current concerns about self-harm or suicide')).toContainText(
-        "OASys Question - 'Describe circumstances, relevant issues and needs regarding current concerns (refer to sections 1-12 for indicators, particularly Section 1' - Answer Input - 'Test concerns about self-harm and suicide'"
+        "OASys Question - '8.1.1 Are there any current concerns about suicide & self-harm - Ans: Test circumstances, relevant issues and needs regarding current concerns'"
     )
     await expect(page.getByLabel('Current concerns about Coping in Custody or Hostel')).toContainText(
-        "OASys Question - 'R8.2 Coping in custody / hostel setting - Describe circumstances, relevant issues and needs' - Answer Input - 'Test Issues and Needs'"
+        "OASys Question - 'R8.2.1 Are there any current concerns about coping in custody or Hostel settings - Ans: Test circumstances, relevant issues and needs regarding current concerns"
     )
     await expect(page.getByLabel('Current concerns about Vulnerability')).toContainText(
-        "OASys Question - 'R8.3.1 Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited) - Yes - Describe circumstances, relevant issues and needs' - Answer Input - 'Test Issues and Needs'"
+        "OASys Question - 'R8.3.1 Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited) - Ans: Test circumstances, relevant issues and needs regarding current concerns"
     )
     await page.locator('.govuk-button', { hasText: /Save and continue/ }).click()
 }

--- a/steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self.ts
+++ b/steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self.ts
@@ -2,13 +2,13 @@ import { type Page, expect } from '@playwright/test'
 
 export const verifyRiskToSelfIsAsPerOASys = async (page: Page) => {
     await expect(page.getByLabel('Current concerns about self-harm or suicide')).toContainText(
-        "OASys Question - '8.1.1 Are there any current concerns about suicide & self-harm - Ans: Test circumstances, relevant issues and needs regarding current concerns'"
+        "OASys Question - 'Describe circumstances, relevant issues and needs regarding current concerns (refer to sections 1-12 for indicators, particularly Section 1' - Answer Input - 'Test concerns about self-harm and suicide'"
     )
     await expect(page.getByLabel('Current concerns about Coping in Custody or Hostel')).toContainText(
-        "OASys Question - 'R8.2.1 Are there any current concerns about coping in custody or Hostel settings - Ans: Test circumstances, relevant issues and needs regarding current concerns"
+        "OASys Question - 'R8.2 Coping in custody / hostel setting - Describe circumstances, relevant issues and needs' - Answer Input - 'Test Issues and Needs'"
     )
     await expect(page.getByLabel('Current concerns about Vulnerability')).toContainText(
-        "OASys Question - 'R8.3.1 Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited) - Ans: Test circumstances, relevant issues and needs regarding current concerns"
+        "OASys Question - 'R8.3.1 Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited) - Yes - Describe circumstances, relevant issues and needs' - Answer Input - 'Test Issues and Needs'"
     )
     await page.locator('.govuk-button', { hasText: /Save and continue/ }).click()
 }

--- a/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
+++ b/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
@@ -125,7 +125,7 @@ export const createLayer3CompleteAssessment = async (
     // And I complete Offence Analysis Plan Questions
     await completeOffenceAnalysisYes(page)
 }
-export const createLayer3AssessmentWithoutNeeds = async (page: Page, crn: string) => {
+export const createLayer3AssessmentWithoutNeeds = async (page: Page, crn: string, highRoshScore: boolean = false) => {
     // And I select "Warwickshire" from Choose Provider Establishment
     await selectRegion(page)
     // And I click on the Search button from the top menu
@@ -155,7 +155,7 @@ export const createLayer3AssessmentWithoutNeeds = async (page: Page, crn: string
     // And I Click on "RoSH Summary" Section
     await clickRoSHSummary(page)
     // And I complete "RoSH Summary - R10" Questions
-    await completeRoSHSection10RoSHSummary(page)
+    await completeRoSHSection10RoSHSummary(page, highRoshScore)
     // And I Click on "Risk Management Plan" Section
     await clickRiskManagementPlan(page)
     // And I complete "Risk Management Plan" Questions

--- a/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
+++ b/steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs.ts
@@ -96,6 +96,10 @@ export const createLayer3CompleteAssessment = async (
         await completeRoSHSection5FullAnalysis(page)
         // And I complete "'R8 Risks to the individual - full analysis'" Section 5 and Click Save & Next
         await completeRoSHSection8FullAnalysisYes(page)
+        // And I complete "RoSH Summary - R9" Questions
+        await completeRoSHSection9RoSHSummary(page)
+        // And I complete "RoSH Summary - R10" Questions
+        await completeRoSHSection10RoSHSummary(page, highRoshScore)
     } else {
         console.log('High RoSH Score is false')
         // And I Click on "RoSH Screening" - Section 2 to 4 & and Click Next without selecting/entering anything
@@ -104,12 +108,12 @@ export const createLayer3CompleteAssessment = async (
         await completeRoSHSection5FullAnalysis(page)
         // And I Click on "RoSH Summary" Section
         await clickRoSHSummary(page)
+        // And I complete "RoSH Summary - R9" Questions
+        await completeRoSHSection9RoSHSummary(page)
+        // And I complete "RoSH Summary - R10" Questions
+        await completeRoSHSection10RoSHSummary(page)
     }
 
-    // And I complete "RoSH Summary - R9" Questions
-    await completeRoSHSection9RoSHSummary(page)
-    // And I complete "RoSH Summary - R10" Questions
-    await completeRoSHSection10RoSHSummary(page)
     // And I Click on "Risk Management Plan" Section
     await clickRiskManagementPlan(page)
     // And I complete "Risk Management Plan" Questions

--- a/steps/oasys/layer3-assessment/section-10.ts
+++ b/steps/oasys/layer3-assessment/section-10.ts
@@ -1,6 +1,6 @@
 import { type Page, expect } from '@playwright/test'
 
-export const completeRoSHSection10RoSHSummary = async (page: Page) => {
+export const completeRoSHSection10RoSHSummary = async (page: Page, highRoshScore: boolean = false) => {
     await page.fill('#textarea_SUM1', "OASys Question - 'R10.1 Who is at risk.' - Answer Input - 'Child'")
     await page.fill(
         '#textarea_SUM2',
@@ -18,10 +18,24 @@ export const completeRoSHSection10RoSHSummary = async (page: Page) => {
         '#textarea_SUM5',
         "OASys Question - 'R10.5 - What factors are likely to reduce the risk Describe factors, actions, and events which may reduce or contain the level of risk. What has previously stopped him / her? ' - Answer Input - 'Test Factors to reduce the risk'"
     )
-    await page.locator('#itm_SUM6_1_1').selectOption({ label: 'Very High' })
-    await page.locator('#itm_SUM6_2_1').selectOption({ label: 'Medium' })
-    await page.locator('#itm_SUM6_3_1').selectOption({ label: 'High' })
-    await page.locator('#itm_SUM6_4_1').selectOption({ label: 'Medium' })
+
+    if (highRoshScore) {
+        await page.locator('#itm_SUM6_1_1').selectOption({ label: 'Very High' })
+        await page.locator('#itm_SUM6_2_1').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_3_1').selectOption({ label: 'High' })
+        await page.locator('#itm_SUM6_4_1').selectOption({ label: 'Medium' })
+    } else {
+        await page.locator('#itm_SUM6_1_1').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_2_1').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_3_1').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_4_1').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_1_2').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_2_2').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_3_2').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_4_2').selectOption({ label: 'Medium' })
+        await page.locator('#itm_SUM6_5_2').selectOption({ label: 'Medium' })
+    }
+
     await page.keyboard.down('End')
     await page.click('input[value="Save"]')
     await page.click('input[value="Next"]')

--- a/steps/oasys/layer3-assessment/section-8.ts
+++ b/steps/oasys/layer3-assessment/section-8.ts
@@ -9,7 +9,7 @@ export const completeRoSHSection8FullAnalysisYes = async (page: Page) => {
     await page.getByLabel('Are there any current concerns about self-harm').selectOption({ label: 'Yes' })
     await page.fill(
         '#textarea_FA33',
-        "OASys Question - '8.1.1 Are there any current concerns about suicide & self-harm - Ans: Test circumstances, relevant issues and needs regarding current concerns"
+        "OASys Question - '8.1.1 Are there any current concerns about suicide & self-harm - Ans: Test circumstances, relevant issues and needs regarding current concerns'"
     )
     await page.fill('#itm_FA35', '1000')
     await page.getByLabel('Have there been any concerns about suicide in the past').selectOption({ label: 'Yes' })

--- a/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
+++ b/tests/accredited-programmes-and-oasys/accredited-programmes-and-oasys.spec.ts
@@ -38,7 +38,7 @@ test('View OASys assessments in Accredited Programmes service', async ({ page })
 
     // Step 3: Create a Layer 3 Assessment in OASys
     await oasysLogin(page, UserType.AccreditedProgrammesAssessment)
-    await createLayer3CompleteAssessment(page, crn, person, 'Yes', nomisId)
+    await createLayer3CompleteAssessment(page, crn, person, 'Yes', nomisId, true)
     await signAndlock(page)
 
     // Step 4: Make referral in Accredited Programmes

--- a/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
+++ b/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
@@ -18,10 +18,7 @@ import { verifyRMPInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/ap
 import { verifyOffenceAnalysisIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-offence-analysis'
 import { verifyRiskToSelfIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self'
 import { verifySupportingInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-supporting-info'
-import {
-    createLayer3AssessmentWithoutNeeds,
-    createLayer3CompleteAssessment,
-} from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
+import { createLayer3CompleteAssessment } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
 import { slow } from '../../steps/common/common'
 import { addLayer3AssessmentNeedsReview } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/add-layer3-needs.js'
 

--- a/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
+++ b/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
@@ -18,7 +18,10 @@ import { verifyRMPInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/ap
 import { verifyOffenceAnalysisIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-offence-analysis'
 import { verifyRiskToSelfIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self'
 import { verifySupportingInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-supporting-info'
-import { createLayer3AssessmentWithoutNeeds } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
+import {
+    createLayer3AssessmentWithoutNeeds,
+    createLayer3CompleteAssessment,
+} from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
 import { slow } from '../../steps/common/common'
 import { addLayer3AssessmentNeedsReview } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/add-layer3-needs.js'
 
@@ -43,7 +46,7 @@ test('View OASys assessments in Approved Premises service', async ({ page }) => 
 
     // And I create a Layer 3 Assessment with Needs in OASys
     await oasysLogin(page, UserType.Timeline)
-    await createLayer3AssessmentWithoutNeeds(page, crn)
+    await createLayer3CompleteAssessment(page, crn, person, undefined, undefined, true)
     await addLayer3AssessmentNeedsReview(page)
 
     // When I login in to Approved Premises and navigate to Applications Task-list page

--- a/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
+++ b/tests/approved-premises-and-oasys/assessment-timeline.spec.ts
@@ -18,7 +18,7 @@ import { verifyRMPInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/ap
 import { verifyOffenceAnalysisIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-offence-analysis'
 import { verifyRiskToSelfIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-risk-to-self'
 import { verifySupportingInfoIsAsPerOASys } from '../../steps/cas1-approved-premises/applications/edit-risk-information-supporting-info'
-import { createLayer3CompleteAssessment } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
+import { createLayer3AssessmentWithoutNeeds } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/create-layer3-without-needs'
 import { slow } from '../../steps/common/common'
 import { addLayer3AssessmentNeedsReview } from '../../steps/oasys/layer3-assessment/create-layer3-assessment/add-layer3-needs.js'
 
@@ -43,7 +43,7 @@ test('View OASys assessments in Approved Premises service', async ({ page }) => 
 
     // And I create a Layer 3 Assessment with Needs in OASys
     await oasysLogin(page, UserType.Timeline)
-    await createLayer3CompleteAssessment(page, crn, person, undefined, undefined, true)
+    await createLayer3AssessmentWithoutNeeds(page, crn, true)
     await addLayer3AssessmentNeedsReview(page)
 
     // When I login in to Approved Premises and navigate to Applications Task-list page

--- a/tests/opd-and-delius/opd-assessment.spec.ts
+++ b/tests/opd-and-delius/opd-assessment.spec.ts
@@ -33,7 +33,7 @@ test('OPD assessment creates an event in Delius', async ({ page }) => {
     })
 
     await oasysLogin(page, UserType.OPD)
-    await createLayer3CompleteAssessment(page, crn, person, 'Yes')
+    await createLayer3CompleteAssessment(page, crn, person, 'Yes', undefined, true)
     await signAndlock(page)
 
     await loginDelius(page)


### PR DESCRIPTION
This pull request addresses issues related to the OASys and Delius integration, specifically focusing on ensuring that counter-signature prompts are correctly triggered and that API calls to the integration service are properly recorded.

- Refactored the test code for the test titled "Verify that OASys assessments with Delius registration forces countersignature on a Medium assessment".
- Adjusted the test code to ensure cases are created in the correct state, which has resolved the issue of missing API calls.
- Verified the updated implementation with both pre-fix and post-fix scenarios to confirm that the integration service API calls are now correctly triggered and logged in Application Insights.
- Refactored OPD-OASys, Accredited Programmes-OASys & OASys-Approved Premises tests to bring in line with latest changes"
