### PR TITLE
prepare-a-case-dev Set hearing sitting day to UTC datetime

### DIFF
--- a/steps/court-case/hearing-data.ts
+++ b/steps/court-case/hearing-data.ts
@@ -14,7 +14,7 @@ export const hearingData = (person: Person, courtCode: string = SHEFFIELD_COURT.
         hearingDays: [
             {
                 listedDurationMinutes: 60,
-                sittingDay: DateTime.now().toISO(),
+                sittingDay: DateTime.now().toUTC().toString(),
             },
         ],
         type: {


### PR DESCRIPTION
Set hearing sitting day to UTC datetime as we expect it as UTC (in court-hearing-event-receiver, it comes as LocalDateTime which does not use timezone. We have to look into what it "should" be explicitly.)


<img width="1113" alt="image" src="https://github.com/user-attachments/assets/0c0dc45d-c673-415b-84dd-0e4384f3c442">
