### PR TITLE
Fix SNS publishing for court-case

### DIFF
--- a/steps/court-case/add-court-hearing.ts
+++ b/steps/court-case/add-court-hearing.ts
@@ -6,7 +6,7 @@ export async function addCourtHearing(person: Person, courtCode: string = SHEFFI
     await runPod(
         'court-probation-dev',
         'probation-integration-e2e-tests',
-        'court-case-service',
+        'court-facing-api',
         ['aws sns publish --topic-arn "$TOPIC_ARN" --message "$MESSAGE" --message-attributes "$ATTRIBUTES"'],
         [
             { name: 'TOPIC_ARN', valueFrom: { secretKeyRef: { name: 'court-case-events-topic', key: 'topic_arn' } } },


### PR DESCRIPTION
Change service account name for `court-case`. This is because the service account name has changed recently.

ℹ️ ⚠️ 
This would be a better as a call to `court-hearing-event-receiver` see https://github.com/ministryofjustice/hmpps-probation-in-court-utils/blob/3603fb418cbcecff4a98a8b29673903e33a7d4c7/populate-cher.bash#L104-L109w

The bearer token will need the role `ROLE_COURT_HEARING_EVENT_WRITE` in order to POST hearing updates to `court-hearing-event-receiver`
