### PR TITLE
Revert JamesIves/github-pages-deploy-action to 4.6.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Publish HTML report
         if: always()
-        uses: JamesIves/github-pages-deploy-action@dc18a3c6b46d56484cb63f291becd7ed4f0269b9 # v4
+        uses: JamesIves/github-pages-deploy-action@62fec3add6773ec5dbbf18d2ee4260911aa35cf4 # v4.6.9
         with:
           folder: playwright-report
           target-folder: ${{ env.report-dir }}


### PR DESCRIPTION
v4.7.1 relies on a feature in rsync 3.2, but our self-hosted runner currently only supports rsync 3.1.