### PR TITLE
Fix namespace and service account for common-platform-and-delius test

### DIFF
--- a/tests/common-platform-and-delius/search-for-person.spec.ts
+++ b/tests/common-platform-and-delius/search-for-person.spec.ts
@@ -14,9 +14,9 @@ test('Create and search for a person', async ({ page }) => {
     const address = buildAddress()
 
     await runPod(
-        'hmpps-probation-integration-services-dev',
+        'hmpps-probation-integration',
         'probation-integration-e2e-test',
-        'common-platform-and-delius',
+        'probation-integration',
         ['aws sqs send-message --queue-url "$QUEUEURL" --message-body "$MESSAGEBODY"'],
         [
             {


### PR DESCRIPTION
- Change the namespace and service account for the common-platform-and delius search for person e2e test