### PR TITLE
PI-2758 Update report_dir env var handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,8 +186,10 @@ jobs:
         id: html
         if: always()
         run: |
-          echo '[🎭 Playwright HTML Report](https://ministryofjustice.github.io/hmpps-probation-integration-e2e-tests/${{ env.report-dir }})' | tee -a "$GITHUB_STEP_SUMMARY"
-          echo 'report-url=https://ministryofjustice.github.io/hmpps-probation-integration-e2e-tests/${{ env.report-dir }}' | tee -a "$GITHUB_OUTPUT"
+          echo "[🎭 Playwright HTML Report](https://ministryofjustice.github.io/hmpps-probation-integration-e2e-tests/$report_dir)" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "report-url=https://ministryofjustice.github.io/hmpps-probation-integration-e2e-tests/$report_dir" | tee -a "$GITHUB_OUTPUT"
+        env:
+          report_dir: ${{ env.report-dir }}
 
       - name: Send message to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0


### PR DESCRIPTION
report-dir contains the path used for the HTML report URL, which is constructed as:
```shell
report-dir=playwright-report/test/$REF/$(date '+%Y-%m-%d')/${{ github.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
```
where $REF is the branch name.

Git branch names can contain apostrophes, so this could potentially be abused for shell injection. This change passes the report-dir as an env variable, to ensure quoting is always respected.