### PR TITLE
Fix exports

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
     entry: ['test-data/**', 'steps/**'],
+    exports: {
+        all: true,
+        customExports(exports) {
+            for (const e of Object.keys(exports)) exports[e] = exports[e].replace(/^\.\/dist\//, './')
+            return exports
+        },
+    },
     unbundle: true,
     outDir: 'dist',
     format: 'esm',


### PR DESCRIPTION
so dependents don't need to import with a .mjs file extension