### PR TITLE
adding test and job to clean up address data for a given CRN

### DIFF
--- a/.github/workflows/setup-data.yml
+++ b/.github/workflows/setup-data.yml
@@ -36,6 +36,12 @@ on:
           - hmpps-integration-api
           - create-unallocated-workforce-cases
           - create-unallocated-case-with-documents
+          - delete-addresses-for-crn
+      crn:
+        description: Offenders CRN
+        type: string
+        required: false
+
 jobs:
   create-generic-data:
     uses: ./.github/workflows/test.yml
@@ -55,9 +61,22 @@ jobs:
 
   create-for-project:
     uses: ./.github/workflows/test.yml
-    if: inputs.project != 'none'
+    if: inputs.project != 'none' && inputs.project != 'delete-addresses-for-crn'
     with:
       directory: test-data-setup
       projects: '["${{ inputs.project }}"]'
+      workers: 1
+    secrets: inherit
+
+  delete-for-project:
+    uses: ./.github/workflows/test.yml
+    if: inputs.project == 'delete-addresses-for-crn'
+    with:
+      directory: test-data-setup
+      projects: '["${{ inputs.project }}"]'
+      env: |
+        {
+          "OFFENDER_CRN": "${{ inputs.crn }}"
+        }
       workers: 1
     secrets: inherit

--- a/steps/delius/address/delete-addresses.ts
+++ b/steps/delius/address/delete-addresses.ts
@@ -1,0 +1,20 @@
+import { expect, type Page } from '@playwright/test'
+import { findOffenderByCRN } from '../offender/find-offender'
+
+export const deleteAddresses = async (page: Page, crn: string) => {
+    await findOffenderByCRN(page, crn)
+    await page.getByRole('link', { name: 'Personal Details' }).click()
+    await page.getByRole('link', { name: 'Addresses' }).click()
+    await expect(page.locator('h1')).toContainText('Addresses and Accommodation')
+
+    while ((await page.locator('#otherAddressTable tbody tr').count()) > 1) {
+        await page
+            .locator('#otherAddressTable tbody tr')
+            .first()
+            .locator('a[title="Link to Delete this Address"]')
+            .click()
+        await expect(page.locator('h1')).toContainText('Delete Address')
+        await page.locator('input', { hasText: 'Confirm' }).click()
+        await expect(page.locator('h1')).toContainText('Addresses and Accommodation')
+    }
+}

--- a/steps/delius/offender/find-offender.ts
+++ b/steps/delius/offender/find-offender.ts
@@ -26,7 +26,7 @@ export async function findOffenderByCRN(page: Page, crn: string) {
         await page.locator('tr', { hasText: crn }).locator('a', { hasText: 'View' }).click()
         await dismissModals(page)
     }
-    await expect(page.getByRole('heading', { name: 'Case Summary' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'Case Summary' })).toBeVisible({ timeout: 10000 })
 }
 
 export async function findOffenderByCRNNoContextCheck(page: Page, crn: string) {

--- a/steps/delius/offender/find-offender.ts
+++ b/steps/delius/offender/find-offender.ts
@@ -26,8 +26,7 @@ export async function findOffenderByCRN(page: Page, crn: string) {
         await page.locator('tr', { hasText: crn }).locator('a', { hasText: 'View' }).click()
         await dismissModals(page)
     }
-
-    await expect(page).toHaveTitle(/Case Summary/)
+    await expect(page.getByRole('heading', { name: 'Case Summary' })).toBeVisible({ timeout: 10000 });
 }
 
 export async function findOffenderByCRNNoContextCheck(page: Page, crn: string) {

--- a/test-data-setup/approved-premises-data-creator/delete-addresses-for-crn.spec.ts
+++ b/test-data-setup/approved-premises-data-creator/delete-addresses-for-crn.spec.ts
@@ -1,0 +1,9 @@
+import { test } from '@playwright/test'
+import { login as loginDelius } from '../../steps/delius/login'
+import { deleteAddresses } from '../../steps/delius/address/delete-addresses'
+
+test('Delete previous addresses for a given offender', async ({ page }) => {
+    await loginDelius(page)
+    const crn: string = process.env.OFFENDER_CRN
+    await deleteAddresses(page, crn)
+})


### PR DESCRIPTION
This PR is a result of the CAS3 E2E tests triggering thousands of domain events that each create an address on the same CRN, which caused[ processing issues for CPR ](https://mojdt.slack.com/archives/C03K0HB0LBE/p1741689335710309).

This adds a step which will navigate to the addresses page for a given CRN, and then repeatedly delete any **previous** addresses when there are more than one.