### PR TITLE
CAS-1517 - add address clean up cron job

### DIFF
--- a/.github/workflows/X371199-address-clean-up.yml
+++ b/.github/workflows/X371199-address-clean-up.yml
@@ -1,0 +1,12 @@
+name: X371199 address clean up
+on:
+  schedule:
+    - cron: 0 12 * * *
+jobs:
+  X371199_address_cleanup:
+    name: X371199 address clean up
+    uses: ./.github/workflows/delete-data.yml
+    secrets: inherit
+    with:
+      project: delete-previous-addresses-for-offender
+      crn: X371199


### PR DESCRIPTION
Adding a daily address clean up job until we CAS decide how to proceed with the address clean up 
a) use the playwright steps and delius credentials to log into delius and tidy up on a per-test basis, from the cas3 e2e tests.
b) create a new offender for each test cycle.
c) get a github token and use the cli to trigger the job in the probation-integration-e2e repo