### PR TITLE
PI-3639 – Fixed E2E tests for CVL case view and court case hearing match

### DIFF
--- a/steps/court-case/prepare-case-for-sentence/application.ts
+++ b/steps/court-case/prepare-case-for-sentence/application.ts
@@ -3,11 +3,12 @@ import { DateTime } from 'luxon'
 
 export async function addCourtToUser(page: Page, court: string) {
     await page.getByRole('button', { name: /Accept analytics cookies/ }).click()
+    await page.getByRole('link', { name: 'Edit my courts' }).click()
     await page.focus('#pac-select-court')
     await page.keyboard.type(court)
     await page.keyboard.press('Enter')
     await page.getByRole('button', { name: 'Add' }).click()
-    await page.locator('[href="?save=true"]', { hasText: 'Save  and continue' }).click()
+    await page.locator('[href="?save=true"]', { hasText: 'Save list and continue' }).click()
     await expect(page).toHaveTitle('My courts - Prepare a case for sentence')
     await page.getByRole('link', { name: court }).click()
     await expect(page).toHaveTitle('Case list - Prepare a case for sentence')

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -46,15 +46,15 @@ export const createLicence = async (page: Page, crn: string, nomsNumber: string)
     await page.getByRole('link', { name: /Sign out/ }).click()
 }
 
-export const approveLicence = async (page: Page, crn: string, nomsNumber: string, establishment: string) => {
+export const approveLicence = async (page: Page, nomsNumber: string, establishment: string) => {
     await loginAsPrisonOfficer(page)
     await page.getByRole('link', { name: 'Approve a licence' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - approval cases')
-    await page.getByLabel('Find a case').fill(crn)
-    await page.getByRole('button', { name: 'Search', exact: true }).first().click()
     await page.getByRole('link', { name: 'Licences for other' }).click()
     await page.getByLabel(establishment).check()
     await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByLabel('Find a case').fill(nomsNumber)
+    await page.getByRole('button', { name: 'Search', exact: true }).first().click()
     await page.locator(`tr:has([data-sort-value="${nomsNumber}"]) td#name-1 a.govuk-link`).click()
     await expect(page).toHaveTitle('Create and vary a licence - Approve a licence')
     await page.getByRole('button', { name: /Approve/ }).click()

--- a/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
+++ b/tests/create-and-vary-a-licence-and-delius/view-case.spec.ts
@@ -24,7 +24,7 @@ test('View case in Create and Vary a Licence', async ({ page }) => {
 
     // Create a licence in CVL and approve it.
     await createLicence(page, crn, nomsNumber)
-    await approveLicence(page, crn, nomsNumber, 'Swansea (HMP)')
+    await approveLicence(page, nomsNumber, 'Swansea (HMP)')
 
     // Release the prisoner to apply the licence conditions.
     await releasePrisoner(nomsNumber)


### PR DESCRIPTION
This update fixes the failing end-to-end tests for “View case in Create and Vary a Licence” and “Match Delius case with Court Case Hearing”.
Both tests are now stable and passing in the pipeline after updating the CVL search flow and correcting the court selection logic.