### PR TITLE
Specify node-version-file

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
+      with:
+        node-version-file: .nvmrc
     - name: Download example test script
       run: wget https://raw.githubusercontent.com/microsoft/create-playwright/main/assets/example.spec.ts
       working-directory: tests

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: |
@@ -46,6 +47,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
+          node-version-file: .nvmrc
 
       - run: |
           npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
-          node-version: lts/*
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
+          node-version: lts/*
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Otherwise, the setup-node action relies on the `npm` version on the PATH - which doesn't exist for the HMPPS runners.