### PR TITLE
Change cleanup run time.

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,9 +1,9 @@
 name: Cleanup
 
 on:
-  # Every weekday at 07:00 UTC
+  # Every weekday at 09:00 UTC
   schedule:
-    - cron: "0 7 * * MON-FRI"
+    - cron: "0 9 * * MON-FRI"
   # Run manually via GitHub API
   workflow_dispatch:
 


### PR DESCRIPTION
The address cleanup job is routinely failing, which may indicate on of the downstream services is not running at 07:00, however this job succeeds when ran later in the day. So changing to run at 09:00