### PR TITLE
PI-3689 - Fix Playwright report publishing to work with cross-repo deploy credentials

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -8,6 +8,7 @@ inputs:
   token:
     description: A GitHub personal access token, with "actions:write" permissions to trigger a workflow run in the hmpps-probation-integration-e2e-tests repository
     required: true
+
 outputs:
   failed-projects:
     description: A JSON array of projects that failed end-to-end testing
@@ -23,32 +24,39 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v6
+
     - name: Run tests
       id: run
       shell: bash
       run: |
-        # Start workflow run
+        # Start workflow run in hmpps-probation-integration-e2e-tests
         gh workflow run test.yml --repo "$repo" -f "projects=$projects" && sleep 10 || exit 1
+
+        # Get the run ID of the workflow we just triggered
         run_id=$(gh run list --workflow=test.yml --repo "$repo" -L1 --json databaseId --jq '.[0].databaseId')
         echo "run_id=$run_id" | tee -a "$GITHUB_OUTPUT"
+
+        # Ensure we cancel the remote run if this job is killed
         function cancel_run() { gh run cancel "$run_id" --repo "$repo"; }
         trap cancel_run SIGTERM SIGINT SIGKILL
 
         echo "Workflow started, follow the logs here: https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests/actions/runs/$run_id"
         
-        # Wait for it to complete
+        # Wait for the remote run to complete
         gh run watch "$run_id" --repo "$repo" --interval 60
         
-        # Print any failure logs
+        # Print failure logs (if any)
         gh run view "$run_id" --repo "$repo" --log-failed
         
-        # Parse GitHub outputs from log
+        # Parse GitHub outputs from the remote run logs
         log=$(gh run view "$run_id" --repo "$repo" --log)
-        echo "$log" | sed -n '/ passed-projects=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
-        echo "$log" | sed -n '/ failed-projects=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
-        echo "$log" | sed -n '/ report-url=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
+
+        # These lines MUST emit: key=value so they become step outputs
+        echo "$log" | sed -n '/passed-projects=/s/.*passed-projects=//p' | tee -a "$GITHUB_OUTPUT"
+        echo "$log" | sed -n '/failed-projects=/s/.*failed-projects=//p' | tee -a "$GITHUB_OUTPUT"
+        echo "$log" | sed -n '/report-url=/s/.*report-url=//p'           | tee -a "$GITHUB_OUTPUT"
         
-        # Check status
+        # Check overall status of the remote run
         conclusion=$(gh run view "$run_id" --repo "$repo" --json conclusion --jq '.conclusion')
         echo "Workflow conclusion: $conclusion"
         if [ "$conclusion" != "success" ]; then exit 1; fi
@@ -70,10 +78,12 @@ runs:
       if: always()
       shell: bash
       run: |
+        # passed_projects / failed_projects are JSON arrays, e.g. ["approved-premises-and-delius"]
         passed_count=$(echo "$passed_projects" | jq '. | length')
         failed_count=$(echo "$failed_projects" | jq '. | length')
         total_count=$(( passed_count + failed_count ))
-        echo -e "<table><tr><th><th>Tests</th><th>Passed ✅</th><th>Failed ❌</th></tr><tr><td>End-to-end test results</td><td>$total_count ran</td><td>$passed_count passed</td><td>$failed_count failed</td></tr></table>\n" | tee -a "$GITHUB_STEP_SUMMARY"
+
+        echo -e "<table><tr><th></th><th>Tests</th><th>Passed ✅</th><th>Failed ❌</th></tr><tr><td>End-to-end test results</td><td>$total_count ran</td><td>$passed_count passed</td><td>$failed_count failed</td></tr></table>\n" | tee -a "$GITHUB_STEP_SUMMARY"
         echo "[🎭 Playwright HTML Report]($report_url)" | tee -a "$GITHUB_STEP_SUMMARY"
       env:
         passed_projects: ${{ steps.run.outputs.passed-projects }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -8,7 +8,6 @@ inputs:
   token:
     description: A GitHub personal access token, with "actions:write" permissions to trigger a workflow run in the hmpps-probation-integration-e2e-tests repository
     required: true
-
 outputs:
   failed-projects:
     description: A JSON array of projects that failed end-to-end testing
@@ -24,39 +23,32 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v6
-
     - name: Run tests
       id: run
       shell: bash
       run: |
-        # Start workflow run in hmpps-probation-integration-e2e-tests
+        # Start workflow run
         gh workflow run test.yml --repo "$repo" -f "projects=$projects" && sleep 10 || exit 1
-
-        # Get the run ID of the workflow we just triggered
         run_id=$(gh run list --workflow=test.yml --repo "$repo" -L1 --json databaseId --jq '.[0].databaseId')
         echo "run_id=$run_id" | tee -a "$GITHUB_OUTPUT"
-
-        # Ensure we cancel the remote run if this job is killed
         function cancel_run() { gh run cancel "$run_id" --repo "$repo"; }
         trap cancel_run SIGTERM SIGINT SIGKILL
 
         echo "Workflow started, follow the logs here: https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests/actions/runs/$run_id"
         
-        # Wait for the remote run to complete
+        # Wait for it to complete
         gh run watch "$run_id" --repo "$repo" --interval 60
         
-        # Print failure logs (if any)
+        # Print any failure logs
         gh run view "$run_id" --repo "$repo" --log-failed
         
-        # Parse GitHub outputs from the remote run logs
+        # Parse GitHub outputs from log
         log=$(gh run view "$run_id" --repo "$repo" --log)
-
-        # These lines MUST emit: key=value so they become step outputs
-        echo "$log" | sed -n '/passed-projects=/s/.*passed-projects=//p' | tee -a "$GITHUB_OUTPUT"
-        echo "$log" | sed -n '/failed-projects=/s/.*failed-projects=//p' | tee -a "$GITHUB_OUTPUT"
-        echo "$log" | sed -n '/report-url=/s/.*report-url=//p'           | tee -a "$GITHUB_OUTPUT"
+        echo "$log" | sed -n '/ passed-projects=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
+        echo "$log" | sed -n '/ failed-projects=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
+        echo "$log" | sed -n '/ report-url=/s/.* //p' | tee -a "$GITHUB_OUTPUT"
         
-        # Check overall status of the remote run
+        # Check status
         conclusion=$(gh run view "$run_id" --repo "$repo" --json conclusion --jq '.conclusion')
         echo "Workflow conclusion: $conclusion"
         if [ "$conclusion" != "success" ]; then exit 1; fi
@@ -78,12 +70,10 @@ runs:
       if: always()
       shell: bash
       run: |
-        # passed_projects / failed_projects are JSON arrays, e.g. ["approved-premises-and-delius"]
         passed_count=$(echo "$passed_projects" | jq '. | length')
         failed_count=$(echo "$failed_projects" | jq '. | length')
         total_count=$(( passed_count + failed_count ))
-
-        echo -e "<table><tr><th></th><th>Tests</th><th>Passed ✅</th><th>Failed ❌</th></tr><tr><td>End-to-end test results</td><td>$total_count ran</td><td>$passed_count passed</td><td>$failed_count failed</td></tr></table>\n" | tee -a "$GITHUB_STEP_SUMMARY"
+        echo -e "<table><tr><th><th>Tests</th><th>Passed ✅</th><th>Failed ❌</th></tr><tr><td>End-to-end test results</td><td>$total_count ran</td><td>$passed_count passed</td><td>$failed_count failed</td></tr></table>\n" | tee -a "$GITHUB_STEP_SUMMARY"
         echo "[🎭 Playwright HTML Report]($report_url)" | tee -a "$GITHUB_STEP_SUMMARY"
       env:
         passed_projects: ${{ steps.run.outputs.passed-projects }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          persist-credentials: false # Removed this line of code which is a work around, once fix is in place as per the - https://github.com/JamesIves/github-pages-deploy-action/issues/1928
 
       - name: Get tests to run - all tests
         if: inputs.projects == '' || inputs.projects == 'All'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
       report-url: ${{ steps.html.outputs.report-url }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Get tests to run - all tests
         if: inputs.projects == '' || inputs.projects == 'All'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false # Removed this line of code which is a work around, once fix is in place as per the - https://github.com/JamesIves/github-pages-deploy-action/issues/1928
+          persist-credentials: false # Remove this line of code which is a work around, once fix is in place as per the - https://github.com/JamesIves/github-pages-deploy-action/issues/1928
 
       - name: Get tests to run - all tests
         if: inputs.projects == '' || inputs.projects == 'All'


### PR DESCRIPTION
The Playwright HTML report upload had stopped working because the GitHub runner was using the wrong credentials when pushing to the reports repository.

With actions/checkout@v6, Git now injects credentials differently, and this caused github-pages-deploy-action to fall back to github-actions[bot] instead of using the provided PAT. As a result, pushes to the reports repo were failing even though access is available.

Change Summary:

- Disabled credential persistence in actions/checkout using: persist-credentials: false
- This forces GitHub Pages deploy to correctly use the PAT instead of the injected GITHUB_TOKEN.
- As a result, Playwright reports are now successfully pushed to the reports repository again.