### PR TITLE
PI-3688 – Updated tests to reflect recent application updates and resolve failures

### DIFF
--- a/steps/cas2-short-term-accommodation/application.ts
+++ b/steps/cas2-short-term-accommodation/application.ts
@@ -25,7 +25,7 @@ export async function submitApplication(page: Page, nomisId: string) {
 
 async function startApplication(page: Page) {
     await page.getByRole('link', { name: 'Start a new application' }).click()
-    await expect(page).toHaveTitle('Home - Short-Term Accommodation (CAS-2)')
+    await expect(page).toHaveTitle('Home - CAS2 for HDC - short-term accommodation')
     await page.getByRole('button', { name: 'Start now' }).click()
     await expect(page).toHaveTitle(/Enter the person's prison number/)
 }
@@ -47,7 +47,7 @@ async function confirmEligibilityAndConsent(page: Page) {
     await fillDateInput(page, 'When did they give consent?')
     await page.getByRole('button', { name: 'Save and continue' }).click()
     await expect(page).toHaveTitle(
-        "The person's Home Detention Curfew (HDC) licence dates - Short-Term Accommodation (CAS-2)"
+        "The person's Home Detention Curfew (HDC) licence dates - CAS2 for HDC - short-term accommodation"
     )
     // Fill HDC eligibility date 1 month in the future and ensure it is before the conditional release date
     const hdcEligibilityDate = await fillDateInput(page, 'HDC eligibility date', 1)
@@ -233,7 +233,7 @@ async function riskToOthers(page: Page) {
     await expect(page).toHaveTitle(/Does the person have an older OASys with risk of serious harm \(RoSH\) information/)
     await page.getByLabel('No').check()
     await page.getByRole('button', { name: 'Save and continue' }).click()
-    await expect(page).toHaveTitle(/Create a RoSH summary for this person - Short-Term Accommodation \(CAS-2\)/)
+    await expect(page).toHaveTitle(/Create a RoSH summary for this person - CAS2 for HDC - short-term accommodation/)
     await page.getByRole('group', { name: 'What risk do they pose to children?' }).getByLabel('Low').check()
     await page.getByRole('group', { name: 'What risk do they pose to the public?' }).getByLabel('Medium').check()
     await page.getByRole('group', { name: 'What risk do they pose to a known adult?' }).getByLabel('Medium').check()

--- a/steps/cvl-licences/application.ts
+++ b/steps/cvl-licences/application.ts
@@ -29,7 +29,7 @@ export const createLicence = async (page: Page, crn: string, nomsNumber: string)
     await expect(page).toHaveTitle(
         'Create and vary a licence - Create a licence - What is the contact phone number for the initial appointment?'
     )
-    await page.getByLabel('UK telephone number').first().fill(cvlFormattedPhoneNumber())
+    await page.getByLabel('UK phone number').first().fill(cvlFormattedPhoneNumber())
     await page.getByRole('button', { name: 'Continue' }).click()
     await expect(page).toHaveTitle('Create and vary a licence - Create a licence - When is the initial appointment?')
     await page.getByLabel(/Immediately after release/).check()

--- a/steps/esupervision/check-in.ts
+++ b/steps/esupervision/check-in.ts
@@ -54,7 +54,6 @@ export async function createCheckin(page: Page, uuid: string, person: Person) {
 
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Start recording' }).click()
-    // await page.getByRole('button', { name: 'Submit video anyway' }).click()
     await page.getByRole('button', { name: 'Continue' }).click()
 
     await page.getByRole('checkbox', { name: /I confirm/ }).check()

--- a/steps/esupervision/check-in.ts
+++ b/steps/esupervision/check-in.ts
@@ -54,7 +54,8 @@ export async function createCheckin(page: Page, uuid: string, person: Person) {
 
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Start recording' }).click()
-    await page.getByRole('button', { name: 'Submit video anyway' }).click()
+    // await page.getByRole('button', { name: 'Submit video anyway' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
 
     await page.getByRole('checkbox', { name: /I confirm/ }).check()
     await page.getByRole('button', { name: 'Complete check in' }).click()

--- a/steps/soc/refer-to-soc.ts
+++ b/steps/soc/refer-to-soc.ts
@@ -7,6 +7,7 @@ export const referToSOC = async (page: Page, crn: string) => {
     await page.getByRole('button', { name: 'Search' }).click()
     await page.getByRole('link', { name: 'Add nominal to SOC' }).click()
     // Enter reason for referral
+    await page.getByRole('radio', { name: 'Preselection' }).check()
     await page.getByLabel('Reason for referral or inclusion').fill('Automated testing')
     await page.getByRole('button', { name: 'Save and continue' }).click()
     await page.getByLabel('Directorate of Security (DoS').selectOption('North West and West Midlands')

--- a/test-data-setup/create-unallocated-workforce-cases/create-unallocated-crns-in-workforce.spec.ts
+++ b/test-data-setup/create-unallocated-workforce-cases/create-unallocated-crns-in-workforce.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
 
 test('Create cases awaiting Allocation', async ({ page }) => {
     slow()
-    await createCasesAwaitingAllocation(page, 50)
+    await createCasesAwaitingAllocation(page, 10)
 })
 
 const createCasesAwaitingAllocation = async (page: Page, number: number) => {

--- a/tests/common-platform-and-delius/search-for-person.spec.ts
+++ b/tests/common-platform-and-delius/search-for-person.spec.ts
@@ -38,7 +38,9 @@ test('Create and search for a person', async ({ page }) => {
     await page.getByLabel('First Name or Preferred Name:').fill(person.firstName)
     await page.getByLabel('Last Name:').fill(person.lastName)
     await page.getByRole('button', { name: 'Search', exact: true }).click()
-    await expect(page.getByRole('cell', { name: person.lastName + ', ' + person.firstName, exact: true })).toBeVisible()
+    await expect(
+        page.getByRole('cell', { name: person.lastName + ', ' + person.firstName, exact: true }).first()
+    ).toBeVisible()
     await page.getByRole('link', { name: 'View' }).nth(2).click()
 
     // Check personal details screen information is correct

--- a/tests/court-case-and-delius/match-case.spec.ts
+++ b/tests/court-case-and-delius/match-case.spec.ts
@@ -39,7 +39,7 @@ test('Match Delius case with Court Case Hearing', async ({ page }) => {
 
     // Then the CRN is matched with the hearing and added to the court case service
     await prepareCaseForSentenceLogin(page)
-    await addCourtToUser(page, 'Oxford Magistrates Court')
+    await addCourtToUser(page, "Oxford and Southern Oxfordshire Magistrates' Court")
     const prepareCaseHeader = await searchAndClickDefendantAndGetHeader(page, person.firstName, person.lastName, crn)
     await expect(prepareCaseHeader).toContainText(crn)
     await expect(prepareCaseHeader).toContainText(person.pnc)

--- a/tests/esupervision-and-delius/esupervision-checkin.spec.ts
+++ b/tests/esupervision-and-delius/esupervision-checkin.spec.ts
@@ -35,7 +35,7 @@ test.afterEach(async ({ page }) => {
     await hmppsAuthLogin(page)
     await page.goto(process.env.ESUPERVISION_URL)
     await page.getByRole('link', { name: 'Cases' }).click()
-    await page.getByRole('link', { name: `Manage ${person.firstName} ${person.lastName}` }).click({ timeout: 5000 })
+    await page.getByRole('link', { name: 'Manage' }).last().click({ timeout: 5000 })
     await page.getByRole('link', { name: 'Stop check ins' }).click()
     await page.getByRole('radio', { name: 'Yes' }).check()
     await page.getByRole('textbox', { name: /Explain the reason/ }).fill('Testing')


### PR DESCRIPTION
This PR updates End2End tests to reflect recent changes in the applications and stabilises a number of failing journeys.

The following test flows have now been fixed and are passing again:

- Submit a CAS2 short-term accommodation application
- Create and search for a person
- Match a Delius case with a Court Case Hearing
- View a case in Create and Vary a Licence
- Check-in for an e-Supervision appointment
- Add a community nominal to SOC

**Note:**
The test for “Create a referral and an NSI is created in Delius” is still failing due to the account being locked. The password needs to be reset before this flow can pass