### PR TITLE
PI-3717 - Fix failing E2E tests after recent app updates

### DIFF
--- a/steps/cas2-short-term-accommodation/application.ts
+++ b/steps/cas2-short-term-accommodation/application.ts
@@ -25,7 +25,7 @@ export async function submitApplication(page: Page, nomisId: string) {
 
 async function startApplication(page: Page) {
     await page.getByRole('link', { name: 'Start a new application' }).click()
-    await expect(page).toHaveTitle('Home - CAS2 for HDC - short-term accommodation')
+    await expect(page).toHaveTitle('Home - CAS2 for HDC')
     await page.getByRole('button', { name: 'Start now' }).click()
     await expect(page).toHaveTitle(/Enter the person's prison number/)
 }
@@ -46,9 +46,7 @@ async function confirmEligibilityAndConsent(page: Page) {
     await page.getByLabel(/Yes/).check()
     await fillDateInput(page, 'When did they give consent?')
     await page.getByRole('button', { name: 'Save and continue' }).click()
-    await expect(page).toHaveTitle(
-        "The person's Home Detention Curfew (HDC) licence dates - CAS2 for HDC - short-term accommodation"
-    )
+    await expect(page).toHaveTitle("The person's Home Detention Curfew (HDC) licence dates - CAS2 for HDC")
     // Fill HDC eligibility date 1 month in the future and ensure it is before the conditional release date
     const hdcEligibilityDate = await fillDateInput(page, 'HDC eligibility date', 1)
 
@@ -233,7 +231,7 @@ async function riskToOthers(page: Page) {
     await expect(page).toHaveTitle(/Does the person have an older OASys with risk of serious harm \(RoSH\) information/)
     await page.getByLabel('No').check()
     await page.getByRole('button', { name: 'Save and continue' }).click()
-    await expect(page).toHaveTitle(/Create a RoSH summary for this person - CAS2 for HDC - short-term accommodation/)
+    await expect(page).toHaveTitle(/Create a RoSH summary for this person - CAS2 for HDC/)
     await page.getByRole('group', { name: 'What risk do they pose to children?' }).getByLabel('Low').check()
     await page.getByRole('group', { name: 'What risk do they pose to the public?' }).getByLabel('Medium').check()
     await page.getByRole('group', { name: 'What risk do they pose to a known adult?' }).getByLabel('Medium').check()

--- a/steps/esupervision/check-in.ts
+++ b/steps/esupervision/check-in.ts
@@ -54,7 +54,7 @@ export async function createCheckin(page: Page, uuid: string, person: Person) {
 
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Start recording' }).click()
-    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: /Submit video anyway/ }).click()
 
     await page.getByRole('checkbox', { name: /I confirm/ }).check()
     await page.getByRole('button', { name: 'Complete check in' }).click()


### PR DESCRIPTION
This PR fixes the following end-to-end tests that were failing due to recent application changes.

Tests fixed:

- Submit a CAS2 short-term accommodation application
- Check-in for an e-supervision appointment

Note on remaining failures:

- View case in Create and Vary a Licence is failing due to a Delius-side issue
- Create a referral and NSI is created in Delius is failing because the Auth user password needs to be reset

These are not genuine test issues and will be addressed separately once the external dependencies are resolved.

The earlier problem with Playwright report generation is no longer occurring, so no additional fix is needed there.