### PR TITLE
Fix UPW add project availability step

### DIFF
--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -79,8 +79,7 @@ async function addProjectAvailability(
     await fillDate(page, '#EndDate\\:datePicker', projectAvailability.endDate)
     await page.fill('#StartTime\\:timePicker', projectAvailability.startTime)
     await page.fill('#EndTime\\:timePicker', projectAvailability.endTime)
-    await page.getByRole('button', { name: 'Add', exact: true }).nth(1).click()
-    await page.getByTitle('Project Availability').click()
+    await page.getByRole('button', { name: 'Add', exact: true }).nth(0).click()
     await waitForAjax(page)
     await page.getByRole('button', { name: 'Save' }).click()
 }


### PR DESCRIPTION
### Context
In the project availability step, we attempt to add project availability with the following code:

```ts
    await page.getByRole('button', { name: 'Add', exact: true }).nth(1).click()
    await page.getByTitle('Project Availability').click()
    await waitForAjax(page)
    await page.getByRole('button', { name: 'Save' }).click()
```

However, because the index is incorrect, `.nth(1)` will incorrectly click the button "Add commissioning source" button, causing a validation error:

<img width="754" height="425" alt="image" src="https://github.com/user-attachments/assets/fa2efedf-9cd8-418b-bb8e-ec67b205e323" />

Strangely, this doesn't break the test and somehow the availability is correctly added (see 9 second timestamp in the video below). 

https://github.com/user-attachments/assets/cc840a12-4b40-4aa4-a453-75b80e6fe834

This may be causing flakiness, as we've seen [failures](https://github.com/ministryofjustice/hmpps-community-payback-ui/actions/runs/20753094933/job/59664769119) that look like the person failed to be allocated.

This PR fixes the index and removes the step to click on "Project Availability" as it doesn't seem to be required.

