### PR TITLE
CPB-462: add end date to project creation

### DIFF
--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -51,6 +51,7 @@ export async function createUpwProject(
     await page.fill('#ProjectCode\\:prependedInputText', projectCode)
     await page.fill('#ProjectName\\:inputText', projectName)
     await fillDate(page, '#ProjectStartDate\\:datePicker', new Date())
+    await fillDate(page, '#ProjectEndDate\\:datePicker', Tomorrow.toJSDate())
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('#content > h1')).toContainText('Update Project')
     await addProjectAvailability(page, projectAvailability)


### PR DESCRIPTION
See [CPB-462](https://dsdmoj.atlassian.net/browse/CPB-489). The lack of an end date is overpopulating the project drop down.

[CPB-462]: https://dsdmoj.atlassian.net/browse/CPB-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ