### PR TITLE
CPB-529: Update unpaid work project default start and end times

### DIFF
--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -33,7 +33,7 @@ export async function createUpwProject(
         projectCode?: string
         projectAvailability?: ProjectAvailability
     }
-): Promise<{ projectCode: string; projectName: string }> {
+): Promise<{ projectCode: string; projectName: string; projectAvailability: ProjectAvailability }> {
     await page.getByRole('link', { name: 'UPW Projects' }).click()
     await expect(page.locator('#content > h1')).toContainText('UPW Projects List')
     await page.locator('input', { hasText: 'Add New Project' }).click()
@@ -49,15 +49,18 @@ export async function createUpwProject(
     await fillDate(page, '#ProjectEndDate\\:datePicker', Tomorrow.toJSDate())
     await page.getByRole('button', { name: 'Save' }).click()
     await expect(page.locator('#content > h1')).toContainText('Update Project')
-    await addProjectAvailability(page, projectAvailability)
-    return { projectCode, projectName }
+    const availability = await addProjectAvailability(page, projectAvailability)
+    return { projectCode, projectName, projectAvailability: availability }
 }
 
 export function createNameWithTimeStamp(prefix = 'project'): string {
     return `${prefix}-${DateTime.now().toFormat('ddMMyyyyHHmmss')}`
 }
 
-async function addProjectAvailability(page: Page, projectAvailability: ProjectAvailability) {
+async function addProjectAvailability(
+    page: Page,
+    projectAvailability: ProjectAvailability
+): Promise<ProjectAvailability> {
     const timeNow = DateTime.now()
     // default duration set to 4 hours to ensure the appointment ends on the same day (when running before 8pm)
     const timeLater = timeNow.plus({ hours: 4 })
@@ -81,4 +84,5 @@ async function addProjectAvailability(page: Page, projectAvailability: ProjectAv
     await page.getByRole('button', { name: 'Add', exact: true }).nth(0).click()
     await waitForAjax(page)
     await page.getByRole('button', { name: 'Save' }).click()
+    return { day, frequency, startDate, endDate, startTime, endTime }
 }

--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -5,6 +5,15 @@ import { getCurrentDay, Tomorrow } from '../utils/date-time'
 import { waitForAjax } from '../utils/refresh'
 import { DateTime } from 'luxon'
 
+interface ProjectAvailability {
+    day?: string
+    frequency?: string
+    startDate?: Date
+    endDate?: Date
+    startTime?: string
+    endTime?: string
+}
+
 export async function createUpwProject(
     page: Page,
     {
@@ -14,14 +23,7 @@ export async function createUpwProject(
         pickupPoint = 'Chelmsford',
         projectName = createNameWithTimeStamp(),
         projectCode = faker.string.alphanumeric(6),
-        projectAvailability = {
-            day: getCurrentDay(),
-            frequency: 'Weekly',
-            startDate: new Date(),
-            endDate: Tomorrow.toJSDate(),
-            startTime: '09:00',
-            endTime: '17:00',
-        },
+        projectAvailability = {},
     }: {
         providerName: string
         teamName: string
@@ -29,14 +31,7 @@ export async function createUpwProject(
         pickupPoint?: string
         projectName?: string
         projectCode?: string
-        projectAvailability?: {
-            day: string
-            frequency: string
-            startDate: Date
-            endDate: Date
-            startTime: string
-            endTime: string
-        }
+        projectAvailability?: ProjectAvailability
     }
 ): Promise<{ projectCode: string; projectName: string }> {
     await page.getByRole('link', { name: 'UPW Projects' }).click()
@@ -64,22 +59,22 @@ export function createNameWithTimeStamp(prefix = 'project'): string {
 
 async function addProjectAvailability(
     page: Page,
-    projectAvailability: {
-        day: string
-        frequency: string
-        startDate: Date
-        endDate: Date
-        startTime: string
-        endTime: string
-    }
+    {
+        day = getCurrentDay(),
+        frequency = 'Weekly',
+        startDate = new Date(),
+        endDate = Tomorrow.toJSDate(),
+        startTime = '09:00',
+        endTime = '17:00',
+    }: ProjectAvailability
 ) {
     await page.getByRole('button', { name: 'Project Availability' }).click()
-    await selectOption(page, '#Day\\:selectOneMenu', projectAvailability.day)
-    await selectOption(page, '#Frequency\\:selectOneMenu', projectAvailability.frequency)
-    await fillDate(page, '#StartDate\\:datePicker', projectAvailability.startDate)
-    await fillDate(page, '#EndDate\\:datePicker', projectAvailability.endDate)
-    await page.fill('#StartTime\\:timePicker', projectAvailability.startTime)
-    await page.fill('#EndTime\\:timePicker', projectAvailability.endTime)
+    await selectOption(page, '#Day\\:selectOneMenu', day)
+    await selectOption(page, '#Frequency\\:selectOneMenu', frequency)
+    await fillDate(page, '#StartDate\\:datePicker', startDate)
+    await fillDate(page, '#EndDate\\:datePicker', endDate)
+    await page.fill('#StartTime\\:timePicker', startTime)
+    await page.fill('#EndTime\\:timePicker', endTime)
     await page.getByRole('button', { name: 'Add', exact: true }).nth(0).click()
     await waitForAjax(page)
     await page.getByRole('button', { name: 'Save' }).click()

--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -57,17 +57,20 @@ export function createNameWithTimeStamp(prefix = 'project'): string {
     return `${prefix}-${DateTime.now().toFormat('ddMMyyyyHHmmss')}`
 }
 
-async function addProjectAvailability(
-    page: Page,
-    {
+async function addProjectAvailability(page: Page, projectAvailability: ProjectAvailability) {
+    const timeNow = DateTime.now()
+    // default duration set to 4 hours to ensure the appointment ends on the same day (when running before 8pm)
+    const timeLater = timeNow.plus({ hours: 4 })
+
+    const {
         day = getCurrentDay(),
         frequency = 'Weekly',
         startDate = new Date(),
         endDate = Tomorrow.toJSDate(),
-        startTime = '09:00',
-        endTime = '17:00',
-    }: ProjectAvailability
-) {
+        startTime = timeNow.toISOTime({ precision: 'minute' }),
+        endTime = timeLater.toISOTime({ precision: 'minute' }),
+    } = projectAvailability
+
     await page.getByRole('button', { name: 'Project Availability' }).click()
     await selectOption(page, '#Day\\:selectOneMenu', day)
     await selectOption(page, '#Frequency\\:selectOneMenu', frequency)


### PR DESCRIPTION
There is new validation in the probation-integration-api that states that an unpaid work appointment outcome cannot be updated in the future. This means that any Community Payback e2e tests run before the default time of '09:00' fail. Some tests run after the appointment end time also fail.

This change updates the default project availability times to always be now or in the future. This is not necessarily a realistic user scenario, but should unblock our e2e tests. If no end time is provided, setting the end time to be 4 hours later, which means we are unlikely to run into problems with the end time falling after midnight.

[CPB-529](https://dsdmoj.atlassian.net/browse/CPB-529)

[CPB-529]: https://dsdmoj.atlassian.net/browse/CPB-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ