### PR TITLE
Remove time zone offset from start and end time strings

### DIFF
--- a/steps/delius/upw/create-upw-project.ts
+++ b/steps/delius/upw/create-upw-project.ts
@@ -70,8 +70,8 @@ async function addProjectAvailability(
         frequency = 'Weekly',
         startDate = new Date(),
         endDate = Tomorrow.toJSDate(),
-        startTime = timeNow.toISOTime({ precision: 'minute' }),
-        endTime = timeLater.toISOTime({ precision: 'minute' }),
+        startTime = timeNow.toISOTime({ precision: 'minute', includeOffset: false }),
+        endTime = timeLater.toISOTime({ precision: 'minute', includeOffset: false }),
     } = projectAvailability
 
     await page.getByRole('button', { name: 'Project Availability' }).click()


### PR DESCRIPTION
This is to return unpaid work project details from the data setup step with times in the format `HH:mm` without seconds or timezone details.

[CPB-529](https://dsdmoj.atlassian.net/browse/CPB-529)



[CPB-529]: https://dsdmoj.atlassian.net/browse/CPB-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ