### PR TITLE
CPB 719 UPW ETE Improvements

### DIFF
--- a/steps/delius/upw/allocate-current-case-to-upw-project.ts
+++ b/steps/delius/upw/allocate-current-case-to-upw-project.ts
@@ -11,8 +11,8 @@ export async function allocateCurrentCaseToUpwProject(
         teamName,
         projectName = null,
         day = getCurrentDay(),
-        startTime = '10:00',
-        endTime = '16:00',
+        startTime = null,
+        endTime = null,
         projectType = 'Group Placement - National Project',
         pickupPoint = null,
     }: {
@@ -42,8 +42,14 @@ export async function allocateCurrentCaseToUpwProject(
     await selectOption(page, '#team\\:selectOneMenu', teamName)
     await selectOption(page, '#project\\:selectOneMenu', projectName)
     await selectOption(page, '#allocationDay\\:selectOneMenu')
-    await page.locator('#startTime\\:timePicker').fill(startTime)
-    await page.locator('#endTime\\:timePicker').fill(endTime)
+
+    if (startTime) {
+        await page.locator('#startTime\\:timePicker').fill(startTime)
+    }
+
+    if (endTime) {
+        await page.locator('#endTime\\:timePicker').fill(endTime)
+    }
     await selectOption(page, '#pickupPlace\\:selectOneMenu', pickupPoint)
     await page.getByRole('button', { name: 'Add' }).click()
 

--- a/test-data-setup/create-case-with-unpaid-work-allocation/create-case-with-unpaid-work-allocation.spec.ts
+++ b/test-data-setup/create-case-with-unpaid-work-allocation/create-case-with-unpaid-work-allocation.spec.ts
@@ -35,6 +35,7 @@ test('Create a case with an Unpaid Work Project Allocation', async ({ page }) =>
     await page.locator('a', { hasText: 'Personal Details' }).click()
 
     await allocateCurrentCaseToUpwProject(page, {
+        crn: crn,
         providerName: data.teams.unpaidWorkTestTeam.provider,
         teamName: data.teams.unpaidWorkTestTeam.name,
         projectName: project.projectName,


### PR DESCRIPTION
* Fix upw test-data setup
* When allocating a project to a person it’s now possible to use the default start and end time, instead of explicitly specifying the start and end time to use