### PR TITLE
CPB-858: Add step to verify time credited

### DIFF
--- a/steps/delius/upw/checkAppointmentDetails.ts
+++ b/steps/delius/upw/checkAppointmentDetails.ts
@@ -1,5 +1,6 @@
-import { expect, Locator, Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { waitForAjax } from '../utils/refresh'
+import { getRowByContent, getRowCellsByContent } from '../utils/table'
 
 export type CheckAppointmentOptions = {
     teamProvider: string
@@ -14,43 +15,6 @@ export type CheckAppointmentOptions = {
     enforcementAction?: string
     hoursCredited?: string
     outStanding?: string
-}
-
-async function clickNextButton(page: Page) {
-    const nextButtonSelector = 'a.page-link[title="Next"]:not(.disabled)'
-    await page.waitForSelector(nextButtonSelector, { state: 'visible' })
-
-    await page.click(nextButtonSelector)
-    await waitForAjax(page)
-    await page.waitForSelector('#searchResultsTable tbody')
-
-    return true
-}
-
-async function getRowByContent(page: Page, content: string): Promise<Locator> {
-    const row = page.locator(`#searchResultsTable tbody tr:has-text("${content}")`).first()
-    if (await row.isVisible().catch(() => false)) {
-        return row
-    }
-
-    const nextButton = page.locator('a.page-link[title="Next"]:not(.disabled)')
-
-    if ((await nextButton.count()) > 0) {
-        await clickNextButton(page)
-        return getRowByContent(page, content)
-    }
-    throw new Error(`Row with content "${content}" not found`)
-}
-
-async function getCellContents(row: Locator): Promise<string[]> {
-    const cellElements = await row.locator('td').all()
-
-    return await Promise.all(
-        cellElements.map(async td => {
-            const text = await td.innerText()
-            return text.trim()
-        })
-    )
 }
 
 export async function checkAppointmentOnDelius(
@@ -79,18 +43,14 @@ export async function checkAppointmentOnDelius(
     await waitForAjax(page)
     await page.waitForSelector('h2:text-is("Project List")')
 
-    const row = await getRowByContent(page, projectName)
+    const row = await getRowByContent(page, 'searchResultsTable', projectName)
 
     await row.getByRole('link', { name: 'manage' }).click()
     await page.waitForSelector('h2:text-is("Allocated To Attend")')
 
-    const rowByCrn = page
-        .locator('#allocatedOffendersTable tbody tr')
-        .filter({ has: page.locator(`td:first-child:text-is("${popCrn}")`) })
+    const cells = await getRowCellsByContent(page, 'allocatedOffendersTable', popCrn)
 
-    const cells = await getCellContents(rowByCrn)
-
-    expect(cells[0]).toBe(popCrn)
+    expect(cells[0]).toContain(popCrn)
     expect(cells[1]).toBe(popName)
     expect(cells[2]).toBe(startTime)
     expect(cells[3]).toBe(endTime)

--- a/steps/delius/upw/verify-time-credited.ts
+++ b/steps/delius/upw/verify-time-credited.ts
@@ -1,0 +1,30 @@
+import { Page } from '@playwright/test'
+import { findEventByCRN } from '../event/find-events'
+import { verifyTableRowByContent } from '../utils/table'
+import { waitForAjax } from '../utils/refresh'
+
+interface Options {
+    crn: string
+    eventNumber?: number
+    projectName: string
+    date: Date
+    hoursCredited: string // in format H:mm
+    outcome: string
+}
+
+export default async function verifyTimeCredited(
+    page: Page,
+    { crn, eventNumber = 1, projectName, hoursCredited, outcome }: Options
+): Promise<void> {
+    await findEventByCRN(page, crn, eventNumber)
+    await page.click('#navigation-include\\:linkNavigation3UnpaidWork')
+    await page.getByRole('button', { name: 'Worksheet summary' }).click()
+    await waitForAjax(page)
+
+    const toVerify = [
+        { columnName: 'Hrs Credited', cellContent: hoursCredited },
+        { columnName: 'Outcome', cellContent: outcome },
+    ]
+
+    await verifyTableRowByContent(page, 'appointmentsTable', projectName, toVerify)
+}

--- a/steps/delius/utils/table.ts
+++ b/steps/delius/utils/table.ts
@@ -1,0 +1,39 @@
+import { expect, Locator, Page } from '@playwright/test'
+import { waitForAjax } from './refresh'
+
+export async function getRowByContent(page: Page, tableId: string, content: string): Promise<Locator> {
+    const tableLocator = page.locator(`#${tableId}`)
+    await expect(tableLocator).toBeVisible()
+    const row = tableLocator.getByRole('row').filter({ hasText: content })
+
+    try {
+        await expect(row).toBeVisible()
+        return row
+    } catch {
+        const nextPageButtonLocator = page.getByRole('link', { name: 'Next' })
+        await expect(nextPageButtonLocator, `Expected - ${content} - not found, try next page`).toBeVisible()
+        await nextPageButtonLocator.click()
+        await waitForAjax(page)
+        return getRowByContent(page, tableId, content)
+    }
+}
+
+export async function getRowCellsByContent(page: Page, tableId: string, content: string): Promise<string[]> {
+    const row = await getRowByContent(page, tableId, content)
+    return await row.getByRole('cell').allTextContents()
+}
+
+export async function verifyTableRowByContent(
+    page: Page,
+    tableId: string,
+    rowIdentifyingContent: string,
+    toVerify: Array<{ columnName: string; cellContent: string }>
+) {
+    const tableLocator = page.locator(`#${tableId}`)
+    const rowCellsByContent = await getRowCellsByContent(page, tableId, rowIdentifyingContent)
+    const headerRowCells = await tableLocator.getByRole('columnheader').allTextContents()
+    toVerify.forEach(verification => {
+        const columnIndex = headerRowCells.findIndex(cell => cell.includes(verification.columnName))
+        expect(rowCellsByContent[columnIndex]).toContain(verification.cellContent)
+    })
+}


### PR DESCRIPTION
This adds a step to verify time credited against an appointment for a given CRN via National Search rather than through the UPW Project Diary.

It also verifies total time credited rather than start and end time, as this is the key information on the Worksheet Summary, and is the main data point we are concerned with for our tests related to processing course completions.

Required for [CPB-858](https://dsdmoj.atlassian.net/browse/CPB-858)

## Changes in this PR

- Refactor existing checks for content in tables into new utility methods
- Add a new step for verifying time credited via CRN and event number

[CPB-858]: https://dsdmoj.atlassian.net/browse/CPB-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ